### PR TITLE
Fix namespace URI in sparkletestcast.xml.

### DIFF
--- a/files/sparkletestcast.xml
+++ b/files/sparkletestcast.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:sparkle="http://sparkle-project.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle"  xmlns:dc="http://purl.org/dc/elements/1.1/">
    <channel>
       <title>Sparkle Test App Changelog</title>
       <link>http://sparkle-project.org/files/sparkletestcast.xml</link>


### PR DESCRIPTION
Revert to using the http://www.andymatuschak.org/xml-namespaces/sparkle namespace URI for Sparkle-specific elements.

Fixes sparkle-project/Sparkle#382.
