### PR TITLE
Fix 'Get Sparkle' download link

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             </div>
             <ul id="menu">
                 <li>
-                    <a href="https://github.com/sparkle-project/Sparkle/releases/download/1.8.0/Sparkle-1.8.0.zip"><img src="MenuIcons/MenuIconDownload.png" alt="Download icon" />Get Sparkle 1.8.0</a>
+                    <a href="https://github.com/sparkle-project/Sparkle/releases/download/1.8.0/Sparkle-1.8.0.tar.bz2"><img src="MenuIcons/MenuIconDownload.png" alt="Download icon" />Get Sparkle 1.8.0</a>
                 </li>
                 <li>
                     <a href="https://github.com/sparkle-project/Sparkle/wiki"><img src="MenuIcons/MenuIconDocumentation.png" alt="Documentation icon" />Documentation</a>


### PR DESCRIPTION
.zip to .tar.bz2 (zip returns 404 on github)
