### PR TITLE
Updated to always reference latest Sparkle release

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             </div>
             <ul id="menu">
                 <li>
-                    <a href="https://github.com/sparkle-project/Sparkle/releases/download/1.8.0/Sparkle-1.8.0.tar.bz2"><img src="MenuIcons/MenuIconDownload.png" alt="Download icon" />Get Sparkle 1.8.0</a>
+                    <a href="https://github.com/sparkle-project/Sparkle/releases/latest"><img src="MenuIcons/MenuIconDownload.png" alt="Download icon" />Get Sparkle</a>
                 </li>
                 <li>
                     <a href="https://github.com/sparkle-project/Sparkle/wiki"><img src="MenuIcons/MenuIconDocumentation.png" alt="Documentation icon" />Documentation</a>
@@ -52,18 +52,6 @@
                     <li>Supports <strong>DSA signatures</strong> for ultra-secure updates.</li>
                     <li><strong>Really, really easy</strong> to install.</li>
                     <li>Sparkle <strong>requires no code</strong> in your app, so it's trivial to upgrade or remove the module.</li>
-                </ul>
-                <br class="clear-both" />
-                <p><strong>New</strong> in Sparkle 1.8:</p>
-                <ul class="features">
-                    <li>Up-to-date with 10.10 SDK and Xcode 6. Supports OS X 10.7+.</li>
-                    <li>Cleaned up and modernized code, using ARC and Autolayout.</li>
-                    <li>Truly automatic background updates (no UI at all) when user agreed to automatic updates.</li>
-                    <li>Ability to mark updates as critical.</li>
-                    <li>Progress and status notifications for the host app.</li>
-                    <li>Name of finish_installation.app can be configured to match your app's name.</li>
-                    <li>Merged bugfixes, security fixes and some features from multiple Sparkle forks.</li>
-                    <li>Tons of other stuff!</li>
                 </ul>
                 <br class="clear-both" />
                 <p>With Sparkle, you're in good company. Here are just a few of the hundreds of apps which use Sparkle:</p>


### PR DESCRIPTION
- Updated download link to reference latest release available on GitHub.
- Removed version specific notes as these are available with each release on GitHub.