### PR TITLE
Switched from 'Cocoa' to 'Mac' developers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
                 </li>
             </ul>
             <div id="content">
-                <h3>Sparkle is an easy-to-use software update framework for Cocoa developers.</h3>
+                <h3>Sparkle is an easy-to-use software update framework for Mac developers.</h3>
                 <p>But this little framework's got a lot of features packed inside! Check 'em out:</p>
                 <ul class="features">
                     <li>True self-updating--<strong>no work required from the user.</strong></li>


### PR DESCRIPTION
Sparkle does not require a Cocoa based project.