### PR TITLE
Updated the Sponsored By text and links.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -51,7 +51,7 @@
             <li class="{% if page.id == "about" %} active {% endif %}"><a href="/about/">About</a></li>
             <li class="{% if page.id == "documentation" %} active {% endif %}"><a href="/documentation/">Documentation</a></li>
             <li><a href="//github.com/{{ site.github_username }}/Sparkle">GitHub Project</a></li>
-            <li><a href="//www.bandwidthhog.com/?utm_source=sparkle-www&amp;utm_medium=link&amp;utm_campaign=nav">Sponsor: Bandwidth Hog</a></li>
+            <li><a href="//www.maxcdn.com/?utm_source=sparkle-www&amp;utm_medium=link&amp;utm_campaign=nav">Sponsor: MaxCDN</a></li>
           </ul>
         </div><!--/.navbar-collapse -->
       </div>
@@ -67,7 +67,7 @@
           <footer>
             <p>©&#8202;{{ site.time | date: '%Y' }} Sparkle Project. All Rights Reserved.</p>
             <p>This website is <a rel="alternate" href="//github.com/{{ site.github_username }}/sparkle-project.github.io/blob/master/{{page.path}}">open source</a>.</p>
-            <p>Project Sponsor:<br/><a href="//www.bandwidthhog.com/?utm_source=sparkle-www&amp;utm_medium=link&amp;utm_campaign=footer">Bandwidth Hog</a> by MaxCDN</p>
+            <p>Project Sponsor:<br/><a href="//www.maxcdn.com/?utm_source=sparkle-www&amp;utm_medium=link&amp;utm_campaign=footer">MaxCDN</a></p>
           </footer>
         </div>
       </div>


### PR DESCRIPTION
We are shutting down the Bandwidth Hog brand and migrating everything over to the MaxCDN brand.