### PR TITLE
Add recommentation to distributing apps on a dev's website

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -7,6 +7,18 @@ title: Documentation
 
 Follow these simple steps, and you'll have your app auto-updating ASAP. Note that Sparkle does [not yet support](https://github.com/{{ site.github_username }}/Sparkle/issues/363) sandboxed applications.
 
+### 0. Distributing your App
+
+Before even updating your application, you will first want to consider the method used for distribution. If you use a package installer, you may skip reading this section.
+
+We recommend the following:
+
+* Ship your application as a dmg on your product's website. Add an `/Applications` symlink in your dmg, or otherwise encourage the user to copy the app out of it. For updating your app through Sparkle, other supported archive formats like zip are still okay.
+* Avoid placing your app inside another folder in your archive. If you ship an archive that is not a dmg on your product's website, which we do not recommend, the archive should then not contain multiple items. An exception to this guideline is if you use a signed dmg, but please be careful - the system may not warn you if the dmg is not signed properly!
+* Sign the dmg using macOS 10.11.5 or later if you have a Developer ID Application certificate available from Apple. If you attempt signing with an older OS, this will not work correctly. Be sure to verify the dmg is signed after downloading it from your server. Signed dmg's are backwards compatible to older systems.
+
+These guidelines follow Apple's best practices and works best with App Translocation which affects macOS 10.12 and later. When an application is running from a dmg or is translocated, Sparkle will not be able to update your application. Therefore, you should distribute your application in a way that will most likely be moved by the user.
+
 ### 1. Add the Sparkle framework to your project
 
 If you are using [CocoaPods](https://cocoapods.org), then follow these [alternate instructions](/documentation/cocoapods).


### PR DESCRIPTION
This takes app translocation in macOS 10.12 and later into account. This may not be relevant to Sparkle completely (just like how App Transport Security isn't), but this will trip up developers that aren't aware of App Translocation, so it is probably worth bringing up.

See second half of the WWDC video for "What's New in Security" on the details regarding app translocation: https://developer.apple.com/videos/play/wwdc2016/706/

Apple is going to be pushing pretty hard on distributing dmg's and code signing them. Feel free to make suggestions with wording or where it should be placed or what not else.