### PR TITLE
Updating Cocoapods docs

### DIFF
--- a/documentation/cocoapods/index.md
+++ b/documentation/cocoapods/index.md
@@ -10,7 +10,7 @@ Installing with [CocoaPods](//cocoapods.org/pods/Sparkle) is identical to the [n
 ### 1. Add the Sparkle framework to your project
 
 * Add `pod 'Sparkle'` to your Podfile.
-* Add or uncomment `use_frameworks!` to your Podfile.
+* Add or uncomment `use_frameworks!` in your Podfile.
 
 ### 2. Code Signing Sparkle
 

--- a/documentation/cocoapods/index.md
+++ b/documentation/cocoapods/index.md
@@ -11,8 +11,14 @@ Installing with [CocoaPods](//cocoapods.org/pods/Sparkle) is identical to the [n
 
 * Add `pod 'Sparkle'` to your Podfile.
 * Add or uncomment `use_frameworks!` to your Podfile.
-* The Sparkle framework must be signed. CocoaPods doesn't seem to handle this automatically, so a build script is required (courtesy of [furbo.org](http://furbo.org/2013/10/17/code-signing-and-mavericks/)).
-* Add a 'Run Script' build phase after the 'Copy Pods Resources' phase and enter the following script (you'll need to substitute 'Example' with your own iTunes identity):
+
+### 2. Code Signing Sparkle
+
+**If you are using Xcode 7 or later, this step is automatically handled and should be skipped.**
+
+If the application is signed, then the framework must be also signed via a build script (courtesy of [furbo.org](http://furbo.org/2013/10/17/code-signing-and-mavericks/)).
+
+Add a 'Run Script' build phase after the 'Copy Pods Resources' phase and enter the following script (you'll need to substitute 'Example' with your own iTunes identity):
 
       LOCATION="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
 
@@ -21,6 +27,7 @@ Installing with [CocoaPods](//cocoapods.org/pods/Sparkle) is identical to the [n
 
       codesign --verbose --force --sign "$CODE_SIGN_IDENTITY" "$LOCATION/Sparkle.framework/Versions/A"
 
-That's all. Build your project to confirm that it builds and signs the framework, then continue with the [basic setup](/documentation/#set-up-a-sparkle-updater-object).
+### 3. Finalizing
+Build your project to confirm that it builds and signs the framework, then continue with the [basic setup](/documentation/#set-up-a-sparkle-updater-object).
 
 The Sparkle Project maintains its own CocoaPod Podspec and it is kept up-to-update in sync with official releases.

--- a/documentation/cocoapods/index.md
+++ b/documentation/cocoapods/index.md
@@ -10,6 +10,7 @@ Installing with [CocoaPods](//cocoapods.org/pods/Sparkle) is identical to the [n
 ### 1. Add the Sparkle framework to your project
 
 * Add `pod 'Sparkle'` to your Podfile.
+* Add or uncomment `use_frameworks!` to your Podfile.
 * The Sparkle framework must be signed. CocoaPods doesn't seem to handle this automatically, so a build script is required (courtesy of [furbo.org](http://furbo.org/2013/10/17/code-signing-and-mavericks/)).
 * Add a 'Run Script' build phase after the 'Copy Pods Resources' phase and enter the following script (you'll need to substitute 'Example' with your own iTunes identity):
 

--- a/documentation/cocoapods/index.md
+++ b/documentation/cocoapods/index.md
@@ -9,7 +9,7 @@ Installing with [CocoaPods](//cocoapods.org/pods/Sparkle) is identical to the [n
 
 ### 1. Add the Sparkle framework to your project
 
-* Add `pod 'Sparkle', '~> 1.10'` to your Podfile.
+* Add `pod 'Sparkle'` to your Podfile.
 * The Sparkle framework must be signed. CocoaPods doesn't seem to handle this automatically, so a build script is required (courtesy of [furbo.org](http://furbo.org/2013/10/17/code-signing-and-mavericks/)).
 * Add a 'Run Script' build phase after the 'Copy Pods Resources' phase and enter the following script (you'll need to substitute 'Example' with your own iTunes identity):
 


### PR DESCRIPTION
Only thing I'm going to note is that I believe `use_frameworks!` should be used, although I'm not entirely familiar with Cocoapods myself. It's not enabled by default though because iOS required static libraries for a long time. However in our case we don't have a static library which I think is uncommon for Mac libraries. Also anybody using Swift needs to use this setting as well. If `use_frameworks!` isn't used, then cocoa pods embeds an unnecessary static library as far as I can tell.