### PR TITLE
Add section for Sparkle 2.x documentation

### DIFF
--- a/_layouts/documentation-v2.html
+++ b/_layouts/documentation-v2.html
@@ -5,8 +5,8 @@ layout: default
   <div class="row">
     <div class="col-md-12">
 		<ul class="nav nav-tabs">
-		  <li role="presentation" class="active"><a href="/documentation/">Sparkle 1.x</a></li>
-		  <li role="presentation"><a href="/documentation/v2/">Sparkle 2.x (Beta)</a></li>
+		  <li role="presentation"><a href="/documentation/">Sparkle 1.x</a></li>
+		  <li role="presentation" class="active"><a href="/documentation/v2/">Sparkle 2.x (Beta)</a></li>
 		</ul>
     </div>
   </div>

--- a/documentation/v2/index.md
+++ b/documentation/v2/index.md
@@ -1,0 +1,16 @@
+---
+layout: documentation-v2
+id: documentation
+title: Documentation for Sparkle 2
+---
+
+## Getting Started
+
+Sparkle 2.x is the upcoming new version of Sparkle with support for sandboxed applications.
+
+It is currently in beta.
+
+We're working on the documentation. In the mean time, please have a look at the [README file](https://github.com/sparkle-project/Sparkle/blob/2.x/README.markdown) for details.
+
+
+


### PR DESCRIPTION
As a first step to get started with the docs for Sparkle 2.x, this PR adds a tab bar to the documentation section for switching between the docs for Sparkle 1.x and Sparkle 2.x.

Docs for Sparkle 2.x go into a subfolder (/documentation/v2/). They have a separate layout (`documentation-v2`), so we can easily add banners to outdated documentation pages in the future.