### PR TITLE
Allow an appcast to prevent the new version from being installed automatically

### DIFF
--- a/documentation/customization/index.md
+++ b/documentation/customization/index.md
@@ -28,7 +28,7 @@ Here are the main routes by which you can bend Sparkle's behavior to your will:
 {:.table .table-bordered}
 | Key | Type | Value |
 | --- | ---- | ----- | ------- |
-| `sparkle:doNotAutomaticallyUpdate` | Boolean | Default: `NO`. If this is set to `YES` / `1` in a given appcast, the `SUAutomaticallyUpdate` user defaults value will have no effect - the update referenced by this appcast will not be applied automatically. This is useful for paid updates that should not be applied without an explicit user decision. |
+| `sparkle:automaticallyUpdate` | Boolean | Default: `true` - the `SUAutomaticallyUpdate` user defaults value will apply. If this is set to `false` in a given appcast, the `SUAutomaticallyUpdate` user defaults value will have no effect - the update referenced by this appcast will not be applied automatically. This is useful for paid updates that should not be applied without an explicit user decision. |
 
 ### Calls to SUUpdater
 

--- a/documentation/customization/index.md
+++ b/documentation/customization/index.md
@@ -17,11 +17,18 @@ Here are the main routes by which you can bend Sparkle's behavior to your will:
 | `SUPublicEDKey` | String | The base64-encoded public EdDSA key. Use Sparkle's `generate_keys` tool to get it. |
 | `SUEnableSystemProfiling` | Boolean | Default: `NO`. Enables anonymous system profiling. See [System Profiling](/documentation/system-profiling) for more. |
 | `SUScheduledCheckInterval` | Number | The number of seconds between updates. The default is `86400` (1 day). Setting to 0 disables updates. <br /><br />**Note:** this has a minimum bound of 1 hour in order to keep you from accidentally overloading your servers. |
-| `SUAllowsAutomaticUpdates` | Boolean | Default: `YES`. Sparkle presents your users with the *option* to allow to automatically download and install any available updates. Set this to `NO` to disallow automatic updates and require manual installation every time. |
+| `SUAllowsAutomaticUpdates` | Boolean | Default: `YES`. Sparkle presents your users with the *option* to allow to automatically download and install any available updates. Set this to `NO` to disallow automatic updates and require manual installation every time. Override this for individual updates using the `sparkle:doNotAutomaticallyUpdate` appcast setting. |
 | `SUAutomaticallyUpdate` | Boolean | Default: `NO`. Enables automatic download and installation of updates. If set to `YES`, users will not be informed about updates, and updates will be silently installed when the app quits.
 | `SUShowReleaseNotes` | Boolean | Default: `YES`. Set this to `NO` to hide release notes display from the update alert. |
 | `SUBundleName` | String | Optional alternative bundle display name. For example, if your bundle name already has a version number appended to it, setting this may help smooth out certain messages, e.g. "MyApp 3 4.0 is now available" vs "MyApp 4.0 is now available". |
 | `SUDefaultsDomain` | String | Optional alternative `NSUserDefaults` domain name if you don't want to use the standard user defaults, for example when accessing preferences from an App Group suite. |
+
+### Appcast Settings
+
+{:.table .table-bordered}
+| Key | Type | Value |
+| --- | ---- | ----- | ------- |
+| `sparkle:doNotAutomaticallyUpdate` | Boolean | Default: `NO`. If this is set to `YES` / `1` in a given appcast, the `SUAutomaticallyUpdate` user defaults value will have no effect - the update referenced by this appcast will not be applied automatically. This is useful for paid updates that should not be applied without an explicit user decision. |
 
 ### Calls to SUUpdater
 

--- a/documentation/customization/index.md
+++ b/documentation/customization/index.md
@@ -17,18 +17,11 @@ Here are the main routes by which you can bend Sparkle's behavior to your will:
 | `SUPublicEDKey` | String | The base64-encoded public EdDSA key. Use Sparkle's `generate_keys` tool to get it. |
 | `SUEnableSystemProfiling` | Boolean | Default: `NO`. Enables anonymous system profiling. See [System Profiling](/documentation/system-profiling) for more. |
 | `SUScheduledCheckInterval` | Number | The number of seconds between updates. The default is `86400` (1 day). Setting to 0 disables updates. <br /><br />**Note:** this has a minimum bound of 1 hour in order to keep you from accidentally overloading your servers. |
-| `SUAllowsAutomaticUpdates` | Boolean | Default: `YES`. Sparkle presents your users with the *option* to allow to automatically download and install any available updates. Set this to `NO` to disallow automatic updates and require manual installation every time. Override this for individual updates using the `sparkle:doNotAutomaticallyUpdate` appcast setting. |
+| `SUAllowsAutomaticUpdates` | Boolean | Default: `YES`. Sparkle presents your users with the *option* to allow to automatically download and install any available updates. Set this to `NO` to disallow automatic updates and require manual installation every time. |
 | `SUAutomaticallyUpdate` | Boolean | Default: `NO`. Enables automatic download and installation of updates. If set to `YES`, users will not be informed about updates, and updates will be silently installed when the app quits.
 | `SUShowReleaseNotes` | Boolean | Default: `YES`. Set this to `NO` to hide release notes display from the update alert. |
 | `SUBundleName` | String | Optional alternative bundle display name. For example, if your bundle name already has a version number appended to it, setting this may help smooth out certain messages, e.g. "MyApp 3 4.0 is now available" vs "MyApp 4.0 is now available". |
 | `SUDefaultsDomain` | String | Optional alternative `NSUserDefaults` domain name if you don't want to use the standard user defaults, for example when accessing preferences from an App Group suite. |
-
-### Appcast Settings
-
-{:.table .table-bordered}
-| Key | Type | Value |
-| --- | ---- | ----- | ------- |
-| `sparkle:automaticallyUpdate` | Boolean | Default: `true` - the `SUAutomaticallyUpdate` user defaults value will apply. If this is set to `false` in a given appcast, the `SUAutomaticallyUpdate` user defaults value will have no effect - the update referenced by this appcast will not be applied automatically. This is useful for paid updates that should not be applied without an explicit user decision. |
 
 ### Calls to SUUpdater
 

--- a/documentation/publishing/index.md
+++ b/documentation/publishing/index.md
@@ -87,6 +87,19 @@ Add a `sparkle:minimumSystemVersion` child to the `<item>` in question specifyin
 
 Note that Sparkle only works with macOS 10.7 or later, so that's the minimum version you can use.
 
+## Preventing automatic updates
+
+If an update to your application is a paid upgrade, you may want to prevent it from being applied automatically.
+
+Add a `sparkle:minimumAutoupdateVersion` child to the `<item>` in question specifying the paid update's `<CFBundleVersion>`, such as "1248.48":
+
+    <item>
+        <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
+        <sparkle:minimumAutoupdateVersion>1248.48</sparkle:minimumAutoupdateVersion>
+    </item>
+
+If this value is set, it indicates the lowest version that can automatically update to the version referenced by the appcast (i.e. without showing the _update available_ GUI). Apps with a lower `CFBundleVersion` will always see the _update available_ GUI, regardless of their `SUAutomaticallyUpdate` user defaults setting.
+
 ## Embedded release notes
 
 Instead of linking external release notes using the `<sparkle:releaseNotesLink>` element, you can also embed the release notes directly in the appcast item, inside a `<description>` element. If you wrap it in `<![CDATA[ ... ]]>`, you can use unescaped HTML.


### PR DESCRIPTION
This is the documentation update that goes along with a feature update for which there is a corresponding pull request in the Sparkle project.

Allow an individual appcast to override the SUAutomaticallyUpdate user defaults setting and prevent the new version from being installed automatically. This is helpful if the version referenced by the appcast is a paid upgrade that should not be applied without an explicit user decision. To use this feature, the new appcast property "sparkle:doNotAutomaticallyUpdate" shall be set to 1 or YES.