### PR TITLE
Document support and migration path for non-archived pkg or mpkg updates

### DIFF
--- a/documentation/package-updates/index.md
+++ b/documentation/package-updates/index.md
@@ -15,7 +15,7 @@ An automatic archived installation occurs when Sparkle finds a `*.pkg` or `*.mpk
 
 ### Automatic Bare Installation
 
-Sparkle [1.26 or later](/documentation/upgrading/) supports serving and signing flat `*.pkg` or `*.mpkg` packages directly without having to zip or archive them. You may want to keep archiving them however until majority of your users update to your application with a version of Sparkle that supports this.
+Sparkle [1.26 or later](/documentation/upgrading/) supports serving and signing flat `*.pkg` or `*.mpkg` packages directly without having to zip or archive them. You will want to keep archiving them however until majority of your users update to your application with a version of Sparkle that supports this.
 
 ### Interactive Archived UI Installation
 

--- a/documentation/package-updates/index.md
+++ b/documentation/package-updates/index.md
@@ -5,22 +5,22 @@ title: Package Updates
 ---
 ## Package Updates
 
-Guided Package Installation allows Sparkle to download and install a package, `pkg`, or multi-package, `mpkg`, without user interaction (other than asking for an administrator password).
+Package installation allows Sparkle to update your application by downloading and installing a package, `pkg`, or multi-package, `mpkg` usually without user interaction except for asking for an administrator password.
 
-### Automatic installation
+### Automatic Flat Package Installation
 
-A guided installation occurs when Sparkle finds a `*.pkg` or `*.mpkg` file in the root of the download archive. [Older versions](/documentation/upgrading/) of Sparkle required the filename to be `*.sparkle_guided.pkg`, so you may want to keep that name until majority if your users updates to app with Sparkle 1.16 or later.
+Sparkle supports developers serving and signing flat `*.pkg` or `*.mpkg` packages directly without having to zip or archive them. [Older versions](/documentation/upgrading/) of Sparkle require archiving package files however, so you may want to keep archiving them until majority of your users update to your application with Sparkle <place-holder-version> or later. Read further below if this applies to you.
 
-The installer package is installed using macOS's built-in command line installer, `/usr/sbin/installer`. No installation interface is shown to the user.
+### Automatic Archived Installation
 
-A guided installation can be started by applications other than the application being replaced. This is particularly useful where helper applications or agents are used.
+An automatic archived installation occurs when Sparkle finds a `*.pkg` or `*.mpkg` file in the root of the download archive. [Even older versions](/documentation/upgrading/) of Sparkle required the filename to be `*.sparkle_guided.pkg` to perform an automatic installation, so you may want to keep that name until majority of your users update to your application with Sparkle 1.16 or later.
 
-**Note**: For Sparkle 2.0 (Beta), you must add `sparkle:installationType="package"` to your appcast item for updating guided packages.
+**Note**: For Sparkle 2.0 (Beta), you must add `sparkle:installationType="package"` to your appcast item for updating automatic packages that are archived.
 
-### Interactive GUI Installer
+### Interactive Archived UI Installation
 
 An interactive installation occurs when Sparkle finds a `*.sparkle_interactive.pkg` or `*.sparkle_interactive.mpkg` file in the root of the download archive.
 
-The package will be installed using macOS's built-in GUI installer. The installation will require user to manually click through the steps, so we don't recommend this type of installation. This type of installation is also deprecated in Sparkle 2.x and may be removed one day.
+The package will be installed using macOS's built-in GUI installer. The installation will require user to manually click through the steps, so we don't recommend this type of installation. You must also archive your package update to get this behavior. This type of installation is deprecated in Sparkle 2 and may be removed one day.
 
 **Note**: For Sparkle 2.0 (Beta), you must add `sparkle:installationType="interactive-package"` to your appcast item for updating interactive packages.

--- a/documentation/package-updates/index.md
+++ b/documentation/package-updates/index.md
@@ -7,15 +7,15 @@ title: Package Updates
 
 Package installation allows Sparkle to update your application by downloading and installing a package, `pkg`, or multi-package, `mpkg` usually without user interaction except for asking for an administrator password.
 
-### Automatic Flat Package Installation
-
-Sparkle supports developers serving and signing flat `*.pkg` or `*.mpkg` packages directly without having to zip or archive them. [Older versions](/documentation/upgrading/) of Sparkle require archiving package files however, so you may want to keep archiving them until majority of your users update to your application with Sparkle <place-holder-version> or later. Read further below if this applies to you.
-
 ### Automatic Archived Installation
 
-An automatic archived installation occurs when Sparkle finds a `*.pkg` or `*.mpkg` file in the root of the download archive. [Even older versions](/documentation/upgrading/) of Sparkle required the filename to be `*.sparkle_guided.pkg` to perform an automatic installation, so you may want to keep that name until majority of your users update to your application with Sparkle 1.16 or later.
+An automatic archived installation occurs when Sparkle finds a `*.pkg` or `*.mpkg` file in the root of the download archive. [Older versions](/documentation/upgrading/) of Sparkle required the filename to be `*.sparkle_guided.pkg` to perform an automatic installation, so you may want to keep that name until majority of your users update to your application with Sparkle 1.16 or later.
 
 **Note**: For Sparkle 2.0 (Beta), you must add `sparkle:installationType="package"` to your appcast item for updating automatic packages that are archived.
+
+### Automatic Bare Installation
+
+Sparkle [1.26 or later](/documentation/upgrading/) supports serving and signing flat `*.pkg` or `*.mpkg` packages directly without having to zip or archive them. You may want to keep archiving them however until majority of your users update to your application with a version of Sparkle that supports this.
 
 ### Interactive Archived UI Installation
 

--- a/documentation/upgrading/index.md
+++ b/documentation/upgrading/index.md
@@ -45,9 +45,13 @@ org.sparkle-project.InstallerLauncher.xpc/Contents/MacOS/Updater.app/
 
 Please see the additional setup on using XPC Services and using Sparkle in [sandboxed applications](/documentation/sandboxing). Note using the XPC Services are only required for sandboxed applications, which Sparkle 1.x didn't support.
 
-If you use package (pkg) based updates, please see [Package Updates](/documentation/package-updates) for migration notes. In particular, your appcast items must now include an appropriate installation type now to help Sparkle decide if authorization is needed ahead of time.
+If you use package (pkg) based updates, please see [Package Updates](/documentation/package-updates) for migration notes. In particular, your appcast items may need to include an appropriate installation type to help Sparkle decide if authorization is needed ahead of time.
 
 See [Sparkle 2.x's APIs](/documentation/customization#sparkle-2x-apis-beta) for more information.
+
+## Upgrading from Sparkle <placeholder-version> and older
+
+Support for serving non-archived flat packages (`*.pkg` or `*.mpkg`) has been added. Please see [Package Updates](/documentation/package-updates) for migration details.
 
 ## Upgrading from Sparkle 1.20 and older
 

--- a/documentation/upgrading/index.md
+++ b/documentation/upgrading/index.md
@@ -51,7 +51,7 @@ See [Sparkle 2.x's APIs](/documentation/customization#sparkle-2x-apis-beta) for 
 
 ## Upgrading from Sparkle 1.26 and older
 
-Support for serving bare, or non-archived, flat packages (`*.pkg` or `*.mpkg`) has been added. Please see [Package Updates](/documentation/package-updates) for migration details.
+Support for serving bare, or non-archived, flat packages (`*.pkg` or `*.mpkg`) has been added, but you should still use archived packages until majority of your users update. Please see [Package Updates](/documentation/package-updates) for migration details.
 
 ## Upgrading from Sparkle 1.20 and older
 

--- a/documentation/upgrading/index.md
+++ b/documentation/upgrading/index.md
@@ -49,9 +49,9 @@ If you use package (pkg) based updates, please see [Package Updates](/documentat
 
 See [Sparkle 2.x's APIs](/documentation/customization#sparkle-2x-apis-beta) for more information.
 
-## Upgrading from Sparkle <placeholder-version> and older
+## Upgrading from Sparkle 1.26 and older
 
-Support for serving non-archived flat packages (`*.pkg` or `*.mpkg`) has been added. Please see [Package Updates](/documentation/package-updates) for migration details.
+Support for serving bare, or non-archived, flat packages (`*.pkg` or `*.mpkg`) has been added. Please see [Package Updates](/documentation/package-updates) for migration details.
 
 ## Upgrading from Sparkle 1.20 and older
 


### PR DESCRIPTION
What `placeholder-version` can I use? I.e, do we have an expected version we can guarantee the support will be in or will we need to hold onto this PR until it ships?

Unrelated specifically to this (but with timing consideration), I want to switch the default development branch to 2.x pretty soon but probably not until after 1.25.0 is released. If this specific feature we want to slate for 1.26.0 and the 2.x dev branch switch is done before 1.26.0 (likely small release) that would technically still be okay.