### PR TITLE
Update documentation (part 1)

### DIFF
--- a/documentation/bundles/index.md
+++ b/documentation/bundles/index.md
@@ -42,8 +42,10 @@ The subclass only needs to implement the following two methods:
 
 The story with updating bundles between Sparkle 1 and 2 is a bit different.
 
-First, Sparkle 2 supports updating any Sparkle-based bundle, which is not just limited to your own application or process. The updater distinguishes the `hostBundle` from the `applicationBundle`. The `hostBundle` is the bundle that Sparkle updates and the `applicationBundle` is the bundle that is re-launched (if applicable). See [Sparkle 2's APIs](/documentation/customization#sparkle-2x-apis-beta) for more information on instantiating your own updater.
+First, Sparkle 2 supports updating any Sparkle-based bundle, which is not just limited to your own application or process. The updater distinguishes the `hostBundle` from the `applicationBundle`. The `hostBundle` is the bundle that Sparkle updates and the `applicationBundle` is the bundle that can be terminated and re-launched (if applicable). See [Sparkle 2's APIs](/documentation/customization#sparkle-2x-apis-beta) for more information on instantiating your own updater. Some kinds of plug-ins in particular may want to use `SURelaunchHostBundle` key there for re-launching the host bundle.
 
 Second, Sparkle 2 doesn't keep track of shared updater instances and doesn't try to prohibit multiple updater instances from existing  -- either inside the same process or multiple updaters updating the same bundle from different processes. In fact, it is even possible for one updater to start an update (say a silent deferred one), and for a second updater (say sparkle-cli) to resume that same update for the same bundle.
 
 If you want to update a plug-in, injecting Sparkle.framework or sharing a version of Sparkle with the host process is not advisable. Instead, look into calling out to an out-of-process tool that can update the plug-in like [sparkle-cli](/documentation/sparkle-cli) can.
+
+If your plug-in inherits a sandbox environment, you may need to use a companion application with XPC Services and follow Sparkle's [Sandboxing guide](/documentation/sandboxing).

--- a/documentation/customization/index.md
+++ b/documentation/customization/index.md
@@ -22,6 +22,8 @@ Here are the main routes by which you can bend Sparkle's behavior to your will:
 | `SUShowReleaseNotes` | Boolean | Default: `YES`. Set this to `NO` to hide release notes display from the update alert. |
 | `SUBundleName` | String | Optional alternative bundle display name. For example, if your bundle name already has a version number appended to it, setting this may help smooth out certain messages, e.g. "MyApp 3 4.0 is now available" vs "MyApp 4.0 is now available". |
 | `SUDefaultsDomain` | String | Optional alternative `NSUserDefaults` domain name if you don't want to use the standard user defaults, for example when accessing preferences from an App Group suite. |
+| `SUEnableJavaScript` | Boolean | Default: `NO`. Set this to `YES` if you want to allow JavaScript in your release notes. |
+| `SURelaunchHostBundle` | Boolean | Default: `NO`. For plug-ins in Sparkle 2, set this to `YES` to re-launch the host targetted bundle instead of the application bundle. For example, this can be used to re-open a System Preferences prefpane after an update has been installed.
 
 ### Sparkle 1 APIs
 

--- a/documentation/delta-updates/index.md
+++ b/documentation/delta-updates/index.md
@@ -35,22 +35,21 @@ Version 2 patches created by BinaryDelta are not backwards compatible with Spark
 
     <item>
        <title>Version 2.0 </title>
+       <link>https://myproductwebsite.com</link>
+       <sparkle:version>2.0</sparkle:version>
        <description>foo bar baz</description>
        <pubDate>Wed, 09 Jan 2006 19:20:11 +0000</pubDate>
        <enclosure url="http://you.com/2.0_full.zip"
-                  sparkle:version="2.0"
                   length="123"
                   type="application/octet-stream"
                   sparkle:edSignature="..." />
        <sparkle:deltas>
            <enclosure url="http://you.com/1.5-2.0.delta"
-                      sparkle:version="2.0"
                       sparkle:deltaFrom="1.5"
                       length="1485"
                       type="application/octet-stream"
                       sparkle:edSignature="..." />
            <enclosure url="http://you.com/1.6-2.0.delta"
-                      sparkle:version="2.0"
                       sparkle:deltaFrom="1.6"
                       length="1428"
                       type="application/octet-stream"

--- a/documentation/publishing/index.md
+++ b/documentation/publishing/index.md
@@ -30,19 +30,20 @@ To manually generate signatures for your updates, Sparkle includes a tool to hel
 The output will be an XML fragment with your update's EdDSA signature and (optional) file size; you'll add this attribute to your enclosure in the next step.
 
 Since 10.11, macOS has [App Transport Security](//developer.apple.com/library/prerelease/mac/technotes/App-Transport-Security-Technote/) policy which blocks apps from using insecure HTTP connections. This restriction applies to Sparkle as well, so you will need to serve your appcast and the update files over HTTPS.
-
+f
 ### Update your appcast
 
 You need to create an `<item>` for your update in your appcast. See the [sample appcast](/files/sparkletestcast.xml) for an example. Here's a template you might use:
 
     <item>
         <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
+        <link>https://myproductwebsite.com</link>
+        <sparkle:version>2.0</sparkle:version>
         <sparkle:releaseNotesLink>
             https://example.com/release_notes/app_2.0.html
         </sparkle:releaseNotesLink>
         <pubDate>Mon, 05 Oct 2015 19:20:11 +0000</pubDate>
         <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
-                   sparkle:version="2.0"
                    sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
                    length="1623481"
                    type="application/octet-stream" />
@@ -59,7 +60,7 @@ If you want to provide a download link, instead of having Sparkle download and i
       <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
       <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
       <sparkle:version>1.2.4</sparkle:version>
-      <link>https://example.com/manual_update_info.html</link>
+      <link>https://myproductwebsite.com</link>
     </item>
 
 ## Delta updates
@@ -70,35 +71,43 @@ If your app is large, or if you're updating primarily only a small part of it, y
 
 If you use internal build numbers for your `CFBundleVersion` key and a human-readable `CFBundleShortVersionString`, you can make Sparkle hide the internal version from your users.
 
-Set the `sparkle:version` attribute on your enclosure to the internal, machine-readable version (ie: "1248"). Then set a `sparkle:shortVersionString` attribute on the enclosure to the human-readable version (ie: "1.5.1").
+Set the `sparkle:version` element in your item to the internal, machine-readable version (ie: "1248"). Then set a `sparkle:shortVersionString` element on in your item to the human-readable version (ie: "1.5.1").
 
-[Remember](//lists.apple.com/archives/carbon-dev/2006/Jun/msg00139.html) that the internal version number (`CFBundleVersion` and `sparkle:version`) is intended to be machine-readable and is not generally suitable for formatted text.
+Note that the internal version number (`CFBundleVersion` and `sparkle:version`) is intended to be machine-readable and is not generally suitable for formatted text.
 
 ## Minimum system version requirements
 
 If an update to your application raises the required version of macOS, you can only offer that update to qualified users.
 
-Add a `sparkle:minimumSystemVersion` child to the `<item>` in question specifying the required system version, such as "10.8.4":
+Add a `sparkle:minimumSystemVersion` child to the `<item>` in question specifying the required system version, such as "10.11.0" (be sure to specify a three-part version in form of *major.minor.patch*):
 
     <item>
         <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
-        <sparkle:minimumSystemVersion>10.8.4</sparkle:minimumSystemVersion>
+        <link>https://myproductwebsite.com</link>
+        <sparkle:version>2.0</sparkle:version>
+        <sparkle:minimumSystemVersion>10.11.0</sparkle:minimumSystemVersion>
     </item>
 
-Note that Sparkle only works with macOS 10.7 or later, so that's the minimum version you can use.
+Note that Sparkle only works with macOS 10.9 or later (macOS 10.11 or later for Sparkle 2), so that's the minimum version you can use.
 
-## Preventing automatic updates
+## Major upgrades
 
-If an update to your application is a paid upgrade, you may want to prevent it from being applied automatically.
+If an update to your application is a major or paid upgrade, you may want to prevent the update from being applied automatically.
 
-Add a `sparkle:minimumAutoupdateVersion` child to the `<item>` in question specifying the paid update's `<CFBundleVersion>`, such as "1248.48":
+Add a `sparkle:minimumAutoupdateVersion` child to the `<item>` in question specifying the major update's `<CFBundleVersion>`, such as "2.0":
 
     <item>
-        <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
-        <sparkle:minimumAutoupdateVersion>1248.48</sparkle:minimumAutoupdateVersion>
+        <title>Version 2.1 (2 bugs fixed; 3 new features)</title>
+        <link>https://myproductwebsite.com</link>
+        <sparkle:version>2.1</sparkle:version>
+        <sparkle:minimumAutoupdateVersion>2.0</sparkle:minimumAutoupdateVersion>
     </item>
 
 If this value is set, it indicates the lowest version that can automatically update to the version referenced by the appcast (i.e. without showing the _update available_ GUI). Apps with a lower `CFBundleVersion` will always see the _update available_ GUI, regardless of their `SUAutomaticallyUpdate` user defaults setting.
+
+Additionally in Sparkle 2:
+* A developer can publish a new minor patch release preceding the major release and Sparkle will prefer to install the latest minor release available. For example, if 2.0 is marked as a major release (with `sparkle:minimumAutoupdateVersion` set), but 1.9.4 is available then 1.9.4 will be offered first.
+* A user can choose to skip out of future update alerts to a major upgrade. For example, if 2.0 is a major release offered and the user is on 1.9.4, they can choose to skip 2.0. Sparkle will confirm with the user if they want to skip automatic alerts for 2.0 and future updates (eg 2.1). The user can later undo this if they check for updates manually.
 
 ## Embedded release notes
 
@@ -106,6 +115,8 @@ Instead of linking external release notes using the `<sparkle:releaseNotesLink>`
 
     <item>
         <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
+        <link>https://myproductwebsite.com</link>
+        <sparkle:version>2.0</sparkle:version>
         <description><![CDATA[
             <h2>New Features</h2>
             ...
@@ -134,7 +145,3 @@ To keep the appcast file compatible with the standard Sparkle implementation, a 
     <sparkle:enclosure sparkle:os="os_name" ...>
 
 Replace _os_name_ with either "windows" or "linux", respectively (mind the lower case!). Feel free to add other OS names as needed.
-
-## Xcode integration
-
-[There's an old description](//web.archive.org/web/20120708050000/http://www.entropy.ch/blog/Developer/2008/09/22/Sparkle-Appcast-Automation-in-Xcode.html) of how to automate the archiving and signing process with a script build phase in Xcode. [Find other guides](//www.google.com/search?q=Sparkle+Appcast+Automation).

--- a/documentation/publishing/index.md
+++ b/documentation/publishing/index.md
@@ -30,7 +30,7 @@ To manually generate signatures for your updates, Sparkle includes a tool to hel
 The output will be an XML fragment with your update's EdDSA signature and (optional) file size; you'll add this attribute to your enclosure in the next step.
 
 Since 10.11, macOS has [App Transport Security](//developer.apple.com/library/prerelease/mac/technotes/App-Transport-Security-Technote/) policy which blocks apps from using insecure HTTP connections. This restriction applies to Sparkle as well, so you will need to serve your appcast and the update files over HTTPS.
-f
+
 ### Update your appcast
 
 You need to create an `<item>` for your update in your appcast. See the [sample appcast](/files/sparkletestcast.xml) for an example. Here's a template you might use:

--- a/documentation/sandboxing/index.md
+++ b/documentation/sandboxing/index.md
@@ -23,7 +23,9 @@ If you build Sparkle yourself, you can optionally choose to change `XPC_SERVICE_
 
 #### Installer Launcher Service
 
-The Installer Launcher Service is required. This service bundles a copy of Sparkle's helper tools `Autoupdate` and `Updater.app`. To optimize for space, a sandboxed application that uses this service may optionally choose to remove the helper tools from the `Sparkle.framework` and re-sign the framework:
+The Installer Launcher Service is required. This service bundles a copy of Sparkle's helper tools `Autoupdate` and `Updater.app`.
+
+To optimize for space, a sandboxed application that uses this service may optionally choose to remove the helper tools from the `Sparkle.framework` and re-sign the framework:
 
 ```
 rm -f Sparkle.framework/Autoupdate

--- a/documentation/upgrading/index.md
+++ b/documentation/upgrading/index.md
@@ -10,6 +10,8 @@ We strongly recommend upgrading Sparkle to the [latest production release](//git
 
 **Note**: Sparkle 2.0 is in a pre-release / beta state and not production ready yet.
 
+Sparkle 2 now requires macOS 10.11 (El Capitan) or later.
+
 The `SUUpdater` class has been deprecated and split up in Sparkle 2, but it is still functional for transitional purposes.
 
 Sparkle 2 includes three new classes / protocols:
@@ -23,7 +25,7 @@ If you were previously instantiating a `SUUpdater` in code, you will want to ado
 
 The deprecated `SUUpdater` in 2 is now a stub that uses both a `SPUUpdater` and `SPUStandardUserDriver`.
 
-If you create a `SPUUpdater` instance programatically, you can now create an updater that can update other Sparkle-based bundles and/or an updater that can use your own `SPUUserDriver` / user interface. [sparkle-cli](/documentation/sparkle-cli) makes use of both features as an example.
+If you create a `SPUUpdater` instance programatically, you are now able to create an updater that can update other Sparkle-based bundles and/or an updater that can use your own `SPUUserDriver` / user interface. [sparkle-cli](/documentation/sparkle-cli) makes use of both features as an example.
 
 `SPUUpdater` and its delegate `SPUUpdaterDelegate` (unlike `SUUpdater`) do not contain any user-interface or AppKit logic. The UI bits were separated into classes implementing `SPUUserDriver` and its delegates. A developer writing their own updater user interface may choose to use the new `SparkleCore` framework which strips out the UI bits that Sparkle provides out of the box.
 
@@ -41,11 +43,11 @@ org.sparkle-project.InstallerLauncher.xpc/Contents/MacOS/Autoupdate
 org.sparkle-project.InstallerLauncher.xpc/Contents/MacOS/Updater.app/
 ```
 
-(In the case of using the `InstallerLauncher` XPC Service, the helpers in Sparkle.framework are unused and can optionally be removed; note in this case you may need to re-sign Sparkle.framework)
-
-Please see the additional setup on using XPC Services and using Sparkle in [sandboxed applications](/documentation/sandboxing). Note using the XPC Services are only required for sandboxed applications, which Sparkle 1 didn't support.
+Sparkle 2 supports [sandboxed applications](/documentation/sandboxing) via integration of XPC Services. Note using the XPC Services are only required for sandboxed applications, which Sparkle 1 didn't support.
 
 If you use package (pkg) based updates, please see [Package Updates](/documentation/package-updates) for migration notes. In particular, your appcast items may need to include an appropriate installation type to help Sparkle decide if authorization is needed before starting the installer.
+
+Sparkle 2 enhances support for [major upgrades](/documentation/publishing#Major-upgrades).
 
 See [Sparkle 2's APIs](/documentation/customization#sparkle-2x-apis-beta) for more information.
 

--- a/files/sparkletestcast.xml
+++ b/files/sparkletestcast.xml
@@ -7,6 +7,8 @@
     <language>en</language>
       <item>
         <title>Version 2.0</title>
+        <link>https://sparkle-project.org</link>
+        <sparkle:version>2.0</sparkle:version>
         <description>
           <![CDATA[
             <ul>
@@ -18,7 +20,7 @@
           ]]>
         </description>
         <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
-        <enclosure url="https://sparkle-project.org/files/Sparkle%20Test%20App.zip" sparkle:version="2.0" length="107758" type="application/octet-stream" sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw==" />
+        <enclosure url="https://sparkle-project.org/files/Sparkle%20Test%20App.zip" length="107758" type="application/octet-stream" sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw==" />
       </item>
   </channel>
 </rss>


### PR DESCRIPTION
* Plug-in bundles & Sandboxing
* Javascript key
* sparkle:version element over attribute changes
* <link> additions (in case Sparkle uses them to fall back on, eg update not found)
* Major upgrades
* Minimum system requirement for 2.x

Several changes I had lying around here locally for some time, just added sparkle:version changes.