### PR TITLE
Update documentation for several recent features

### DIFF
--- a/documentation/eddsa-migration/index.md
+++ b/documentation/eddsa-migration/index.md
@@ -20,7 +20,7 @@ Read the below sections for more details. Chances are they apply to you as you p
 
 ## Upgrading from Sparkle 1.21 or later for Developer ID signed applications
 
-If all of your users are running Sparkle 1.21 or later which introduced EdDSA support and your old and new updates are signed with the same Apple Developer ID code signing certificate, you are able to just remove the DSA public key (`SUPublicDSAKeyFile`) in your new update and remove the DSA signature (`sparkle:dsaSignature`) in your appcast.
+If all of your users are running Sparkle 1.21 or later which introduced EdDSA support and your old and new updates are signed with the same Apple Developer ID code signing certificate, you are able to just remove the DSA public key (`SUPublicDSAKeyFile`) in your new update and remove the DSA signature (`sparkle:dsaSignature`) in your appcast. Your new update will need a EdDSA public key (`SUPublicEDKey`) and EdDSA signature (`sparkle:edSignature`) in the appcast.
 
 This works because Sparkle uses the matching Apple code signature to trust the change in Sparkle public keys in your new application update. Note to test this, you may need to run a build of your application that uses the same code signing certificate (and not one used only for development).
 

--- a/documentation/eddsa-migration/index.md
+++ b/documentation/eddsa-migration/index.md
@@ -1,0 +1,48 @@
+---
+layout: documentation
+id: documentation
+title: Upgrading to EdDSA from DSA
+---
+
+Sparkle before version 1.21 used to use only older DSA signatures, which are now deprecated. They are however still supported for migration purposes. We strongly recommend migrating over to EdDSA (ed25519) and planning to drop DSA signatures in new updates of your applications.
+
+Please read all the sections on this page to get a full picture of how EdDSA migration works.
+
+This guide assumes you are currently shipping updates with a DSA public key using `SUPublicDSAKeyFile`. If you are using `SUPublicDSAKey` key instead, the information below still applies.
+
+## Upgrading from Sparkle 1.27 or later
+
+The most latest versions of Sparkle have complete support in dropping DSA public keys and signatures in new application updates. This includes Sparkle 1.27 (not yet released) and Sparkle 2 beta (as of [July 10, 2021](https://github.com/sparkle-project/Sparkle/pull/1888)). These versions are also optimized by not verifying DSA signatures if both EdDSA and DSA keys are present.
+
+You may first need to ship an update that provides both DSA and EdDSA public keys (`SUPublicDSAKeyFile` and `SUPublicEDKey`) and signatures (`sparkle:dsaSignature` and `sparkle:edSignature`) however before being able to drop DSA. Application updates signed with a Developer ID certifiate may be an exception and be able to shortcut this though.
+
+Read the below sections for more details. Chances are they apply to you as you probably have users running earlier versions of Sparkle.
+
+## Upgrading from Sparkle 1.21 or later for Developer ID signed applications
+
+If all of your users are running Sparkle 1.21 or later which introduced EdDSA support and your old and new updates are signed with the same Apple Developer ID code signing certificate, you are able to just remove the DSA public key (`SUPublicDSAKeyFile`) in your new update and remove the DSA signature (`sparkle:dsaSignature`) in your appcast.
+
+This works because Sparkle uses the matching Apple code signature to trust the change in Sparkle public keys in your new application update. Note to test this, you may need to run a build of your application that uses the same code signing certificate (and not one used only for development).
+
+This approach cannot be used if users are running a version of Sparkle before 1.21, which do not understand EdDSA keys.
+
+## Other upgrade paths
+
+If one of these applies to you:
+
+* You have users running versions of Sparkle below 1.21 (that do not understand EdDSA)
+* You have users running a version of your application that only uses DSA keys, and you do not use Apple code signing or the new and old updates are not signed with the same Deveolper ID certificate.
+* You ship package installer upgrades and have users using a version of your application that only uses DSA keys
+* You ship package installer upgrades and all your users are using a version of your application that has an EdDSA key, but your users are running a version of Sparkle below 1.27
+
+Then we recommend migrating in two steps.
+
+First, ship a new update using Sparkle 1.27 or later that specifies both DSA and EdDSA public keys (`SUPublicDSAKeyFile` and `SUPublicEDKey`) and signatures in your appcast (`sparkle:dsaSignature` and `sparkle:edSignature`). For example, the appcast item enclosure may look similar to:
+
+    <enclosure url="http://sparkle-project.org/myupdate.zip" sparkle:version="2" type="application/octet-stream" sparkle:dsaSignature="MCwCFAdLjBvvjJN0fnfMnn7BCl650VqNAhR+XuFABVK2y8zJn/oKtC1sv58ySQ==" sparkle:edSignature="ify59pDIuduaZcLnLvQjGqNQIAqi4dVgeA3L/e7I7xaqn9pVdiVZH7Na3v+Gp4ElAKJfX4Pfq8cgElfXmZc4Cg==" length="1879795" />
+
+Once all of your users are running a version of your application with these new updates, you can then ship a new update that drops the DSA public keys and signatures in your appcast. Your new appcast item enclosure may look like:
+
+    <enclosure url="http://sparkle-project.org/myupdate.zip" sparkle:version="2" type="application/octet-stream" sparkle:edSignature="ify59pDIuduaZcLnLvQjGqNQIAqi4dVgeA3L/e7I7xaqn9pVdiVZH7Na3v+Gp4ElAKJfX4Pfq8cgElfXmZc4Cg==" length="1879795" />
+
+You may be able to [upgrade using new appcasts](/documentation/publishing#upgrading-to-newer-features) to expedite this process.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -65,29 +65,41 @@ Since Sparkle is downloading executable code to your users' systems, you must be
     * Updates using [Installer package](/documentation/package-updates/) (`.pkg`) *must* be signed with EdDSA.
     * [Binary Delta updates](/documentation/delta-updates/) *must* be signed with EdDSA.
     * [Updates of preference panes and plugins](/documentation/bundles/) *must* be signed with EdDSA.
-    * EdDSA signatures are optional for updates using regular app bundles that are signed with Apple code signing (Apple's Developer ID program), but we still recommended EdDSA signatures as a backup. In Sparkle 2, not supplying EdDSA signatures will emit a deprecation warning.
+    * Updates to regular application bundles that are signed with Apple's Developer ID program are strongly recommended to be signed with EdDSA for better security and fallback. Sparkle now deprecates not using EdDSA for these updates.
 
 #### EdDSA (ed25519) signatures
 
 To prepare signing with EdDSA signatures:
 
-  1. First, run `./bin/generate_keys` tool (from the Sparkle distribution root). This needs to be done only once. This tool will do two things:
+Run `./bin/generate_keys` tool (from the Sparkle distribution root). This needs to be done only once. This tool will do two things:
 
   * It will generate a private key and save it in your login Keychain on your Mac. You don't need to do anything with it, but don't lose access to your Mac's Keychain. If you lose it, you may not be able to issue any new updates!
   * It will print your public key to embed into applications. Copy that key (it's a base64-encoded string). You can run `./bin/generate_keys` again to see your public key at any time.
 
-  2. Add your public key to your app's `Info.plist` as a [`SUPublicEDKey`](/documentation/customization/) property.
+Then add your public key to your app's `Info.plist` as a [`SUPublicEDKey`](/documentation/customization/) property.
 
-Sparkle before version 1.21 used to use only older DSA signatures, which are now deprecated. They are still supported for updating old apps, and both DSA and EdDSA may be used together.
+Here is an example run of `./bin/generate_keys`:
+
+```
+A key has been generated and saved in your keychain. Add the `SUPublicEDKey` key to
+the Info.plist of each app for which you intend to use Sparkle for distributing
+updates. It should appear like this:
+
+    <key>SUPublicEDKey</key>
+    <string>pfIShU4dEXqPd5ObYNfDBiQWcXozk7estwzTnF9BamQ=</string>
+```
+
+You can use the `-x private-key-file` and `-f private-key-file` options to export and import the keys respectively when transferring keys to a new Mac. Otherwise we recommend keeping the keys inside your Mac's keychain.
+
+Please visit [Migrating to EdDSA from DSA](eddsa-migration) if you are still providing DSA signatures so you can learn how to stop supporting them.
 
 #### Apple code signing
 
-If you are code-signing your application via Apple's Developer ID program, Sparkle will ensure the new version's author matches the old version's. Sparkle also performs basic (but not deep) validation for testing if the new application is archived/distributed correctly as you intended.
-
+If you are code-signing your application via Apple's Developer ID program, Sparkle will ensure the new version's author matches the old version's. Sparkle also performs shallow (but not deep) validation for testing if the new application's code signature is valid.
   * Note that embedding the `Sparkle.framework` into the bundle of a Developer ID application requires that you code-sign the framework and its helper tools with your Developer ID keys. Xcode should do this automatically if you create an archive via <samp>Product › Archive</samp> and <samp>Distribute App</samp> choosing <samp>Developer ID</samp> method of distribution.
-  * You can diagnose code signing problems with `codesign --deep -vvv --verify <path-to-app>` for code signing validity, `spctl -a -t exec -vv <path-to-app>` for Gatekeeper validity, and by checking logs in the Console.app. See [Code Signing in Depth](https://developer.apple.com/library/archive/technotes/tn2206/_index.html) for more code signing details.
+  * You can diagnose code signing problems with `codesign --deep -vvv --verify <path-to-app>` for code signing validity, `spctl -a -t exec -vv <path-to-app>` for Gatekeeper validity, and by checking logs in the Console.app. See Apple's [Code Signing in Depth](https://developer.apple.com/library/archive/technotes/tn2206/_index.html) for more code signing details.
 
-If you both code-sign your application and include a public EdDSA key for signing your update archive, Sparkle allows issuing a new update that changes either your code signing certificate or your EdDSA keys. Note however this is a last resort and should *only* be done if you lose access to one of them.
+If you both code-sign your application and include a public EdDSA key for signing your update archive, Sparkle allows issuing a new update that changes either your code signing certificate or your EdDSA keys. Note however this is a last resort and should *only* be done if necessary (like if you lose access to one of them or need to change keys).
 
 ### 4. Distributing your App
 
@@ -105,7 +117,7 @@ If you distribute your app as a ZIP or a tar archive (due to [app translocation]
 
 If your app is running from a read-only mount, you can encourage (if you so desire) your user to move the app into /Applications. Some frameworks, although not officially sanctioned here, exist for this purpose. Note Sparkle will not by default automatically disturb your user if an update cannot be performed.
 
-Sparkle supports updating from DMG, ZIP archives, tarballs, and installer packages, so you can generally reuse the same archive for distribution of your app on your website as well as Sparkle updates.
+Sparkle supports updating from DMG, ZIP archives, tarballs, and installer packages. While you can generally reuse the same archive for distribution of your app on your website, Sparkle favors some formats for serving updates more efficiently and reliably.
 
 For Sparkle, tarballs and ZIPs are fastest and most reliable. DMG are slowest. Installer packages should be used only if absolutely necessary (e.g. kernel extensions).
 

--- a/documentation/sandboxing/index.md
+++ b/documentation/sandboxing/index.md
@@ -12,7 +12,7 @@ Note using Sparkle in a sandboxed application is only supported in Sparkle 2.0, 
 
 In order for Sparkle to work in a sandboxed application, the application must call out to XPC Services to perform the updating and installation. Only the InstallerLauncher XPC Service is strictly required. The other serices are optional depending on your use case.
 
-In an extracted `Sparkle-2.0.0.tar.xz` distribution in the `XPCServices/` directory you will notice:
+In an extracted `Sparkle-2*.tar.xz` distribution in the `XPCServices/` directory you will notice:
 
 * org.sparkle-project.InstallerLauncher.xpc
 * org.sparkle-project.Downloader.xpc & org.sparkle-project.Downloader.entitlements
@@ -66,7 +66,7 @@ If you can:
 * Use Xcode's Archive Organizer to [Distribute your App](/documentation#4-distributing-your-app), which will re-sign your XPC Services with a Developer ID certificate and preserve entitlements / hardened runtime during export
 * Avoid using the Installer Connection & Status Services above, which both need entitlements targetting your application's bundle identifier
 
-Then you can probably skip onto [Adding the XPC Services](#adding-the-xpc-services) section.
+Then you can probably skip onto [Adding the XPC Services](#adding-the-xpc-services) section and do not need to specially re-sign these services.
 
 Otherwise if you use alternate methods of distributing your application, or you need to use a different certificate for development, you can code sign these services by running the `bin/codesign_xpc_service` script. For example:
 
@@ -93,4 +93,4 @@ I used "Developer ID Application" for my certificate; you may need to adjust thi
 
 ### Testing
 
-Due to the XPC Services being code signed with the Hardened Runtime enabled by default, Xcode cannot debug the XPC Services and you may see that updating does not work when your application is attached to Xcode's debugger. You can work around this either by editing your project's Scheme and disabling *Debug XPC services used by app* or by testing your application detached from Xcode.
+Due to the XPC Services being code signed with the Hardened Runtime enabled by default, Xcode may not be able to debug the XPC Services and you may see that updating does not work when your application is attached to Xcode's debugger. You can work around this either by editing your project's Scheme and disabling *Debug XPC services used by app* or by testing your application detached from Xcode.

--- a/documentation/upgrading/index.md
+++ b/documentation/upgrading/index.md
@@ -35,7 +35,6 @@ Downgrades were poorly supported in Sparkle 1 and are now unavailable in Sparkle
 
 The behavior for the `-bestValidUpdateInAppcast:forUpdater:` delegate method on `SPUUpdaterDelegate` has changed. Please review its header documentation for more information. In short:
 * Delta updates cannot be returned. A top level item must be returned.
-* Constructing new appcast items is strongly discouraged.
 * Using this method when [channels](/documentation/publishing#channels) or [other features](/documentation/publishing) can be used instead is discouraged.
 * An empty update can now be returned (via `SUAppcastItem.emptyAppcastItem`)
 * An update whose version is below the current application's version should not be returned if the current application's version is available in the appcast

--- a/documentation/upgrading/index.md
+++ b/documentation/upgrading/index.md
@@ -47,6 +47,8 @@ org.sparkle-project.InstallerLauncher.xpc/Contents/MacOS/Updater.app/
 
 Sparkle 2 supports [sandboxed applications](/documentation/sandboxing) via integration of XPC Services. Note using the XPC Services are only required for sandboxed applications, which Sparkle 1 didn't support.
 
+If you are migrating from earlier alpha versions of Sparkle 2, you may find that some of the XPC Services are now optional and re-signing the services may not be necessary. Please read the updated [sandboxing guide](/documentation/sandboxing) for more information.
+
 If you use package (pkg) based updates, please see [Package Updates](/documentation/package-updates) for migration notes. In particular, your appcast items may need to include an appropriate installation type to help Sparkle decide if authorization is needed before starting the installer.
 
 Sparkle 2 enhances support for [major upgrades](/documentation/publishing#Major-upgrades).
@@ -66,7 +68,9 @@ Support for EdDSA (ed25519) signatures has been added. We recommend migrating to
 
 If you're using `generate_appcast` tool, that's all you need.
 
-If you were using manual DSA signing with the `sign_update` script, the script has been moved to `bin/old_dsa_scripts`. The new `sign_update` tool is only for EdDSA keys. To transition to new keys, you will need to use both tools.
+If you were using manual DSA signing with the `sign_update` script, the script has been moved to `bin/old_dsa_scripts`. The new `sign_update` tool is only for EdDSA keys. To transition to new keys, you may need to use both tools.
+
+Please visit [Migrating to EdDSA from DSA](/documentation/eddsa-migration) for more information.
 
 ## Upgrading from Sparkle 1.15 and older
 

--- a/documentation/upgrading/index.md
+++ b/documentation/upgrading/index.md
@@ -33,6 +33,14 @@ If you create a `SPUUpdater` instance programatically, you are now able to creat
 
 Downgrades were poorly supported in Sparkle 1 and are now unavailable in Sparkle 2 (via `SPARKLE_AUTOMATED_DOWNGRADES`).
 
+The behavior for the `-bestValidUpdateInAppcast:forUpdater:` delegate method on `SPUUpdaterDelegate` has changed. Please review its header documentation for more information. In short:
+* Delta updates cannot be returned. A top level item must be returned.
+* Constructing new appcast items is strongly discouraged.
+* Using this method when [channels](/documentation/publishing#channels) or [other features](/documentation/publishing) can be used instead is discouraged.
+* An empty update can now be returned (via `SUAppcastItem.emptyAppcastItem`)
+* An update whose version is below the current application's version should not be returned if the current application's version is available in the appcast
+* Sparkle filters update items for minimum/maximum OS version requirements before calling this method now
+
 If you have scripts that reference Sparkle.framework's helper tools, here are the new paths (note Autoupdate is now a command line tool and the UI bits moved to Updater.app):
 ```
 Sparkle.framework/Autoupdate (symbolic link to Sparkle.framework/Versions/A/Autoupdate)


### PR DESCRIPTION
* EdDSA migration from DSA
* No EdDSA deprecation
* Channels
* Setting feed programmatically
* Migrating to newer features using new appcast (linked from EdDSA migration)
* Extending the Appcast with custom extensions
* Migration notes from earlier versions of Sparkle 2
* Minor rewording on some pages