### PR TITLE
Add syntax highlighting to code snippets

### DIFF
--- a/documentation/bundles/index.md
+++ b/documentation/bundles/index.md
@@ -26,15 +26,17 @@ An alternative approach is to use a subclass of SUUpdater whose shared instance 
 
 The subclass only needs to implement the following two methods:
 
-	+ (id)sharedUpdater
-	{
-	    return [self updaterForBundle:[NSBundle bundleForClass:[self class]]];
-	}
+```objc
++ (id)sharedUpdater
+{
+    return [self updaterForBundle:[NSBundle bundleForClass:[self class]]];
+}
 
-	- (id)init
-	{
-	    return [self initForBundle:[NSBundle bundleForClass:[self class]]];
-	}
+- (id)init
+{
+    return [self initForBundle:[NSBundle bundleForClass:[self class]]];
+}
+```
 
 ### Sparkle 2 (Beta)
 

--- a/documentation/customization/index.md
+++ b/documentation/customization/index.md
@@ -33,109 +33,115 @@ The `SUUpdater` object is the main controller for the updating system in your ap
 
 Once you have the `SUUpdater` instance, there are a few interesting accessors you could use. Please use them only if you need dynamic behavior (e.g. user preferences). Do not use these functions to set default configuration. Use Info.plist keys to set default configuration instead.
 
-    - (void)setAutomaticallyChecksForUpdates:(BOOL)automaticallyChecks;
-    - (BOOL)automaticallyChecksForUpdates;
+```objc
+- (void)setAutomaticallyChecksForUpdates:(BOOL)automaticallyChecks;
+- (BOOL)automaticallyChecksForUpdates;
 
-    - (void)setUpdateCheckInterval:(NSTimeInterval)interval;
-    - (NSTimeInterval)updateCheckInterval;
+- (void)setUpdateCheckInterval:(NSTimeInterval)interval;
+- (NSTimeInterval)updateCheckInterval;
 
-    - (void)setFeedURL:(NSURL *)feedURL;
-    - (NSURL *)feedURL;
+- (void)setFeedURL:(NSURL *)feedURL;
+- (NSURL *)feedURL;
 
-    - (void)setSendsSystemProfile:(BOOL)sendsSystemProfile;
-    - (BOOL)sendsSystemProfile;
+- (void)setSendsSystemProfile:(BOOL)sendsSystemProfile;
+- (BOOL)sendsSystemProfile;
 
-    - (void)setAutomaticallyDownloadsUpdates:(BOOL)automaticallyDownloadsUpdates;
-    - (BOOL)automaticallyDownloadsUpdates;
+- (void)setAutomaticallyDownloadsUpdates:(BOOL)automaticallyDownloadsUpdates;
+- (BOOL)automaticallyDownloadsUpdates;
+```
 
 There is a risk of race conditions. If you want to make sure these settings are changed before the first automatic update check, you should do this in the `NSApplication` delegate method `-applicationWillFinishLaunching:`. For a non-app bundle you should then make the changes immediately after you first create the `SUUpdater` instance in your code.
 
 A few more methods of interest:
 
-    // This IBAction is meant for a main menu item. Hook up any menu item to this action,
-    // and Sparkle will check for updates and report back its findings through UI.
-    - (IBAction)checkForUpdates:sender;
+```objc
+// This IBAction is meant for a main menu item. Hook up any menu item to this action,
+// and Sparkle will check for updates and report back its findings through UI.
+- (IBAction)checkForUpdates:sender;
 
-    // This kicks off an update meant to be programmatically initiated. That is,
-    // it will display no UI unless it actually finds an update, in which case it
-    // proceeds as usual. If the automated downloading is turned on, however,
-    // this will invoke that behavior, and if an update is found, it will be
-    // downloaded and prepped for installation.
-    //
-    // You do not need to call this. Sparkle calls it automatically according to
-    // the update schedule.
-    - (void)checkForUpdatesInBackground;
+// This kicks off an update meant to be programmatically initiated. That is,
+// it will display no UI unless it actually finds an update, in which case it
+// proceeds as usual. If the automated downloading is turned on, however,
+// this will invoke that behavior, and if an update is found, it will be
+// downloaded and prepped for installation.
+//
+// You do not need to call this. Sparkle calls it automatically according to
+// the update schedule.
+- (void)checkForUpdatesInBackground;
 
-    // This begins a "probing" check for updates which will not actually offer to
-    // update to that version. The delegate methods, though, (up to updater:didFindValidUpdate:
-    // and updaterDidNotFindUpdate:), are called, so you can use that information in your UI.
-    // Essentially, you can use this to UI-lessly determine if there's an update.
-    - (void)checkForUpdateInformation;
+// This begins a "probing" check for updates which will not actually offer to
+// update to that version. The delegate methods, though, (up to updater:didFindValidUpdate:
+// and updaterDidNotFindUpdate:), are called, so you can use that information in your UI.
+// Essentially, you can use this to UI-lessly determine if there's an update.
+- (void)checkForUpdateInformation;
 
-    // Date of last update check. Returns nil if no check has been performed.
-    - (NSDate *)lastUpdateCheckDate;
+// Date of last update check. Returns nil if no check has been performed.
+- (NSDate *)lastUpdateCheckDate;
 
-    // Call this to appropriately schedule or cancel the update checking timer according
-    // to the preferences for time interval and automatic checks. If this SUUpdater instance
-    // was not present during the application's launch, you must call this method to start
-    // the update cycle explicitly.
-    - (void)resetUpdateCycle;
+// Call this to appropriately schedule or cancel the update checking timer according
+// to the preferences for time interval and automatic checks. If this SUUpdater instance
+// was not present during the application's launch, you must call this method to start
+// the update cycle explicitly.
+- (void)resetUpdateCycle;
 
-    - (BOOL)updateInProgress;
+- (BOOL)updateInProgress;
 
-    - (void)setDelegate:(id)delegate; // See below for more information on the delegate.
-    - delegate;
+- (void)setDelegate:(id)delegate; // See below for more information on the delegate.
+- delegate;
+```
 
 #### SUUpdater delegate methods
 
 You can control the SUUpdater's behavior a little more closely by providing it with a delegate. Here are the delegate methods you might implement:
 
-    // Use this to override the default behavior for Sparkle prompting the
-    // user about automatic update checks. You could use this to make Sparkle
-    // prompt for permission on the first launch instead of the second.
-    - (BOOL)updaterShouldPromptForPermissionToCheckForUpdates:(SUUpdater *)bundle;
+```objc
+// Use this to override the default behavior for Sparkle prompting the
+// user about automatic update checks. You could use this to make Sparkle
+// prompt for permission on the first launch instead of the second.
+- (BOOL)updaterShouldPromptForPermissionToCheckForUpdates:(SUUpdater *)bundle;
 
-    - (void)updater:(SUUpdater *)updater didFinishLoadingAppcast:(SUAppcast *)appcast;
+- (void)updater:(SUUpdater *)updater didFinishLoadingAppcast:(SUAppcast *)appcast;
 
-    // If you're using special logic or extensions in your appcast, implement
-    // this to use your own logic for finding a valid update, if any, in the given appcast.
-    - (SUAppcastItem *)bestValidUpdateInAppcast:(SUAppcast *)appcast
-                       forUpdater:(SUUpdater *)bundle;
+// If you're using special logic or extensions in your appcast, implement
+// this to use your own logic for finding a valid update, if any, in the given appcast.
+- (SUAppcastItem *)bestValidUpdateInAppcast:(SUAppcast *)appcast
+                   forUpdater:(SUUpdater *)bundle;
 
-    - (void)updater:(SUUpdater *)updater didFindValidUpdate:(SUAppcastItem *)update;
-    - (void)updaterDidNotFindUpdate:(SUUpdater *)update;
+- (void)updater:(SUUpdater *)updater didFindValidUpdate:(SUAppcastItem *)update;
+- (void)updaterDidNotFindUpdate:(SUUpdater *)update;
 
-    // Sent immediately before installing the specified update.
-    - (void)updater:(SUUpdater *)updater willInstallUpdate:(SUAppcastItem *)update;
+// Sent immediately before installing the specified update.
+- (void)updater:(SUUpdater *)updater willInstallUpdate:(SUAppcastItem *)update;
 
-    // Return YES to delay the relaunch until you do some processing.
-    // Invoke the provided NSInvocation to continue the relaunch.
-    - (BOOL)updater:(SUUpdater *)updater
-            shouldPostponeRelaunchForUpdate:(SUAppcastItem *)update
-            untilInvoking:(NSInvocation *)invocation;
+// Return YES to delay the relaunch until you do some processing.
+// Invoke the provided NSInvocation to continue the relaunch.
+- (BOOL)updater:(SUUpdater *)updater
+        shouldPostponeRelaunchForUpdate:(SUAppcastItem *)update
+        untilInvoking:(NSInvocation *)invocation;
 
-    // Called immediately before relaunching.
-    - (void)updaterWillRelaunchApplication:(SUUpdater *)updater;
+// Called immediately before relaunching.
+- (void)updaterWillRelaunchApplication:(SUUpdater *)updater;
 
-    // Called if the application has been relaunched from an update
-    - (void)updaterDidRelaunchApplication:(SUUpdater *)updater;
+// Called if the application has been relaunched from an update
+- (void)updaterDidRelaunchApplication:(SUUpdater *)updater;
 
-    // This method allows you to provide a custom version comparator.
-    // If you don't implement this method or return nil, the standard version
-    // comparator will be used. See SUVersionComparisonProtocol.h for more.
-    - (id <SUVersionComparison>)versionComparatorForUpdater:(SUUpdater *)updater;
+// This method allows you to provide a custom version comparator.
+// If you don't implement this method or return nil, the standard version
+// comparator will be used. See SUVersionComparisonProtocol.h for more.
+- (id <SUVersionComparison>)versionComparatorForUpdater:(SUUpdater *)updater;
 
-    // Returns the path which is used to relaunch the client after the update
-    // is installed. By default, the path of the host bundle.
-    - (NSString *)pathToRelaunchForUpdater:(SUUpdater *)updater;
+// Returns the path which is used to relaunch the client after the update
+// is installed. By default, the path of the host bundle.
+- (NSString *)pathToRelaunchForUpdater:(SUUpdater *)updater;
 
-    // This method allows you to add extra parameters to the appcast URL,
-    // potentially based on whether or not Sparkle will also be sending along
-    // the system profile. This method should return an array of dictionaries
-    // with keys: "key", "value", "displayKey", "displayValue", the latter two
-    // being human-readable variants of the former two.
-    - (NSArray *)feedParametersForUpdater:(SUUpdater *)updater
-                 sendingSystemProfile:(BOOL)sendingProfile;
+// This method allows you to add extra parameters to the appcast URL,
+// potentially based on whether or not Sparkle will also be sending along
+// the system profile. This method should return an array of dictionaries
+// with keys: "key", "value", "displayKey", "displayValue", the latter two
+// being human-readable variants of the former two.
+- (NSArray *)feedParametersForUpdater:(SUUpdater *)updater
+             sendingSystemProfile:(BOOL)sendingProfile;
+```
 
 #### Other options
 
@@ -151,122 +157,134 @@ The `SPUUpdater` object is the main controller for the updating system in your a
 
 Once you have the `SPUUpdater` instance, there are a few interesting accessors you could use. Please use them only if you need dynamic behavior (e.g. user preferences). Do not use these functions to set default configuration. Use Info.plist keys to set default configuration instead.
 
-    @property (nonatomic) BOOL automaticallyChecksForUpdates;
+```objc
+@property (nonatomic) BOOL automaticallyChecksForUpdates;
 
-    @property (nonatomic) NSTimeInterval updateCheckInterval;
+@property (nonatomic) NSTimeInterval updateCheckInterval;
 
-    @property (nonatomic, readonly) NSURL *feedURL;
+@property (nonatomic, readonly) NSURL *feedURL;
 
-    // Using this method is discouraged. Consider -[SPUUpdaterDelegate feedURLStringForUpdater:] or -[SPUUpdaterDelegate feedParametersForUpdater:sendingSystemProfile:] instead.
-    - (void)setFeedURL:(NSURL *)feedURL;
+// Using this method is discouraged. Consider -[SPUUpdaterDelegate feedURLStringForUpdater:] or -[SPUUpdaterDelegate feedParametersForUpdater:sendingSystemProfile:] instead.
+- (void)setFeedURL:(NSURL *)feedURL;
 
-    @property (nonatomic) BOOL sendsSystemProfile;
+@property (nonatomic) BOOL sendsSystemProfile;
 
-    @property (nonatomic) BOOL automaticallyDownloadsUpdates;
+@property (nonatomic) BOOL automaticallyDownloadsUpdates;
+```
 
 There is a risk of race conditions. If you want to make sure these settings are changed before the first automatic update check, you should do this as soon as possible. For an application instantiating `SPUStandardUpdaterController` in a nib, this will be in the `NSApplication` delegate method `-applicationWillFinishLaunching:`. Otherwise this will be right after a `SPUUpdater` instance is instantiated and before you start the updater in your code.
 
 A few methods of interest if you are instantiating `SPUUpdater` programmatically:
 
-    // This is the SPUUpdater initializer. You choose:
-    // `hostBundle` - The bundle that should be targetted for updating.
-    // `applicationBundle` - The application bundle that should be relaunched and waited for termination. Usually this can be the same as hostBundle. This may differ when updating a plug-in or other non-application bundle.
-    // `userDriver` - The user driver that Sparkle uses for user update interaction. Use a `SPUStandardUserDriver` for Sparkle's standard UI.
-    // `delegate` - The optional delegate for SPUUpdater.
-    - (instancetype)initWithHostBundle:(NSBundle *)hostBundle applicationBundle:(NSBundle *)applicationBundle userDriver:(id <SPUUserDriver>)userDriver delegate:(id<SPUUpdaterDelegate> _Nullable)delegate;
+```objc
+// This is the SPUUpdater initializer. You choose:
+// `hostBundle` - The bundle that should be targetted for updating.
+// `applicationBundle` - The application bundle that should be relaunched and waited for termination. Usually this can be the same as hostBundle. This may differ when updating a plug-in or other non-application bundle.
+// `userDriver` - The user driver that Sparkle uses for user update interaction. Use a `SPUStandardUserDriver` for Sparkle's standard UI.
+// `delegate` - The optional delegate for SPUUpdater.
+- (instancetype)initWithHostBundle:(NSBundle *)hostBundle applicationBundle:(NSBundle *)applicationBundle userDriver:(id <SPUUserDriver>)userDriver delegate:(id<SPUUpdaterDelegate> _Nullable)delegate;
 
-    // This method checks if Sparkle is configured properly, may show a prompt asking for automatic updates (if needed),
-    // and may start an update check if automatic update checking is enabled. Must be called to start the updater.
-    - (BOOL)startUpdater:error:;
+// This method checks if Sparkle is configured properly, may show a prompt asking for automatic updates (if needed),
+// and may start an update check if automatic update checking is enabled. Must be called to start the updater.
+- (BOOL)startUpdater:error:;
 
-    // Checks for updates and display progress while doing so. This is meant for users initiating an update check.
-    - (void)checkForUpdates;
+// Checks for updates and display progress while doing so. This is meant for users initiating an update check.
+- (void)checkForUpdates;
+```
 
 The `SPUUserDriver` protocol is the API in Sparkle for controlling the user interface and interaction. If you are using `SPUStandardUpdaterController` in a nib, you can retrieve the user driver via its `userDriver` property. If you are interested in creating your own user interface, please see the header documentation in [`SPUUserDriver.h`](https://github.com/sparkle-project/Sparkle/blob/2.x/Sparkle/SPUUserDriver.h). Note few of the user-facing delegate methods in Sparkle 1's `SUUpdaterDelegate` were moved to `SPUStandardUserDriverDelegate`.
 
 Properties of interest if you are instantiating the standard user driver `SPUStandardUserDriver` yourself:
 
-    // Indicates whether or not an update is in progress as far as the user's perspective is concerned
-    // A typical application may rely on this property for its check for updates menu item validation
-    // If you were using -[SUUpdater updateInProgress] in Sparkle 1.x, you can use !canCheckForUpdates instead.
-    @property (nonatomic, readonly) BOOL canCheckForUpdates;
+```objc
+// Indicates whether or not an update is in progress as far as the user's perspective is concerned
+// A typical application may rely on this property for its check for updates menu item validation
+// If you were using -[SUUpdater updateInProgress] in Sparkle 1.x, you can use !canCheckForUpdates instead.
+@property (nonatomic, readonly) BOOL canCheckForUpdates;
+```
 
 These are properties of interest if you are using `SPUStandardUpdaterController`. You should hook the outlets in Xcode's interface builder and not programmatically.
 
-    // Interface builder outlet for the updater's delegate
-    @property (nonatomic, weak, nullable) IBOutlet id<SPUUpdaterDelegate> updaterDelegate;
+```objc
+// Interface builder outlet for the updater's delegate
+@property (nonatomic, weak, nullable) IBOutlet id<SPUUpdaterDelegate> updaterDelegate;
 
-    // Interface builder outlet for the user driver's delegate.
-    @property (nonatomic, weak, nullable) IBOutlet id<SPUStandardUserDriverDelegate> userDriverDelegate;
+// Interface builder outlet for the user driver's delegate.
+@property (nonatomic, weak, nullable) IBOutlet id<SPUStandardUserDriverDelegate> userDriverDelegate;
 
-    // Explicitly lets the user check for updates and displays a progress dialog while doing so.
-    // Connect this action to a main menu item if so desired.
-    - (IBAction)checkForUpdates:(id)sender;
+// Explicitly lets the user check for updates and displays a progress dialog while doing so.
+// Connect this action to a main menu item if so desired.
+- (IBAction)checkForUpdates:(id)sender;
+```
 
 More methods of interest on `SPUUpdater`:
 
-    // This kicks off an update meant to be programmatically initiated. That is,
-    // it will display no UI unless it actually finds an update, in which case it
-    // proceeds as usual. If the automated downloading is turned on, however,
-    // this will invoke that behavior, and if an update is found, it will be
-    // downloaded and prepped for installation.
-    //
-    // You do not need to call this. Sparkle calls it automatically according to
-    // the update schedule.
-    - (void)checkForUpdatesInBackground;
+```objc
+// This kicks off an update meant to be programmatically initiated. That is,
+// it will display no UI unless it actually finds an update, in which case it
+// proceeds as usual. If the automated downloading is turned on, however,
+// this will invoke that behavior, and if an update is found, it will be
+// downloaded and prepped for installation.
+//
+// You do not need to call this. Sparkle calls it automatically according to
+// the update schedule.
+- (void)checkForUpdatesInBackground;
 
-    // This begins a "probing" check for updates which will not actually offer to
-    // update to that version. The delegate methods, though, (up to updater:didFindValidUpdate:
-    // and updaterDidNotFindUpdate:), are called, so you can use that information in your UI.
-    // Essentially, you can use this to UI-lessly determine if there's an update.
-    - (void)checkForUpdateInformation;
+// This begins a "probing" check for updates which will not actually offer to
+// update to that version. The delegate methods, though, (up to updater:didFindValidUpdate:
+// and updaterDidNotFindUpdate:), are called, so you can use that information in your UI.
+// Essentially, you can use this to UI-lessly determine if there's an update.
+- (void)checkForUpdateInformation;
 
-    // Date of last update check. Returns nil if no check has been performed.
-    @property (nonatomic, readonly, copy, nullable) NSDate *lastUpdateCheckDate;
+// Date of last update check. Returns nil if no check has been performed.
+@property (nonatomic, readonly, copy, nullable) NSDate *lastUpdateCheckDate;
 
-    // Call this to appropriately schedule or cancel the update checking timer according
-    // to the preferences for time interval and automatic checks.
-    - (void)resetUpdateCycle;
+// Call this to appropriately schedule or cancel the update checking timer according
+// to the preferences for time interval and automatic checks.
+- (void)resetUpdateCycle;
+```
 
 #### Delegate methods
 
 You can control the SPUUpdater's behavior a little more closely by providing it with a delegate. Here are the delegate methods you might implement:
 
-    // Use this to override the default behavior for Sparkle prompting the
-    // user about automatic update checks. You could use this to make Sparkle
-    // prompt for permission on the first launch instead of the second.
-    - (BOOL)updaterShouldPromptForPermissionToCheckForUpdates:(SPUUpdater *)updater;
+```objc
+// Use this to override the default behavior for Sparkle prompting the
+// user about automatic update checks. You could use this to make Sparkle
+// prompt for permission on the first launch instead of the second.
+- (BOOL)updaterShouldPromptForPermissionToCheckForUpdates:(SPUUpdater *)updater;
 
-    - (void)updater:(SPUUpdater *)updater didFinishLoadingAppcast:(SUAppcast *)appcast;
+- (void)updater:(SPUUpdater *)updater didFinishLoadingAppcast:(SUAppcast *)appcast;
 
-    - (void)updater:(SPUUpdater *)updater didFindValidUpdate:(SUAppcastItem *)item;
-    - (void)updaterDidNotFindUpdate:(SPUUpdater *)updater error:(NSError *)error;
+- (void)updater:(SPUUpdater *)updater didFindValidUpdate:(SUAppcastItem *)item;
+- (void)updaterDidNotFindUpdate:(SPUUpdater *)updater error:(NSError *)error;
 
-    // Sent immediately before installing the specified update.
-    - (void)updater:(SPUUpdater *)updater willInstallUpdate:(SUAppcastItem *)item;
+// Sent immediately before installing the specified update.
+- (void)updater:(SPUUpdater *)updater willInstallUpdate:(SUAppcastItem *)item;
 
-    // Return YES to delay the relaunch until you do some processing.
-    // Invoke the provided installHandler block to continue the relaunch.
-    - (BOOL)updater:(SPUUpdater *)updater shouldPostponeRelaunchForUpdate:(SUAppcastItem *)item untilInvokingBlock:(void (^)(void))installHandler;
+// Return YES to delay the relaunch until you do some processing.
+// Invoke the provided installHandler block to continue the relaunch.
+- (BOOL)updater:(SPUUpdater *)updater shouldPostponeRelaunchForUpdate:(SUAppcastItem *)item untilInvokingBlock:(void (^)(void))installHandler;
 
-    // Called immediately before relaunching.
-    - (BOOL)updaterShouldRelaunchApplication:(SPUUpdater *)updater;
+// Called immediately before relaunching.
+- (BOOL)updaterShouldRelaunchApplication:(SPUUpdater *)updater;
 
-    // Specifies what update channels the updater is allowed to look in
-    // Useful for eg beta updates
-    - (NSSet<NSString *> *)allowedChannelsForUpdater:(SPUUpdater *)updater;
+// Specifies what update channels the updater is allowed to look in
+// Useful for eg beta updates
+- (NSSet<NSString *> *)allowedChannelsForUpdater:(SPUUpdater *)updater;
 
-    // Specifies what feed URL to use
-    - (nullable NSString *)feedURLStringForUpdater:(SPUUpdater *)updater;
+// Specifies what feed URL to use
+- (nullable NSString *)feedURLStringForUpdater:(SPUUpdater *)updater;
 
-    // This method allows you to provide a custom version comparator.
-    // If you don't implement this method or return nil, the standard version
-    // comparator will be used. See SUVersionComparisonProtocol.h for more.
-    - (nullable id<SUVersionComparison>)versionComparatorForUpdater:(SPUUpdater *)updater;
+// This method allows you to provide a custom version comparator.
+// If you don't implement this method or return nil, the standard version
+// comparator will be used. See SUVersionComparisonProtocol.h for more.
+- (nullable id<SUVersionComparison>)versionComparatorForUpdater:(SPUUpdater *)updater;
 
-    // This method allows you to add extra parameters to the appcast URL,
-    // potentially based on whether or not Sparkle will also be sending along
-    // the system profile. This method should return an array of dictionaries
-    // with keys: "key", "value", "displayKey", "displayValue", the latter two
-    // being human-readable variants of the former two.
-    - (NSArray *)feedParametersForUpdater:(SPUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
+// This method allows you to add extra parameters to the appcast URL,
+// potentially based on whether or not Sparkle will also be sending along
+// the system profile. This method should return an array of dictionaries
+// with keys: "key", "value", "displayKey", "displayValue", the latter two
+// being human-readable variants of the former two.
+- (NSArray *)feedParametersForUpdater:(SPUUpdater *)updater sendingSystemProfile:(BOOL)sendingProfile;
+```

--- a/documentation/delta-updates/index.md
+++ b/documentation/delta-updates/index.md
@@ -19,11 +19,15 @@ The `./bin/generate_appcast` tool that comes with Sparkle [automatically generat
 
 To generate a `.delta`, you use the `BinaryDelta` tool included with Sparkle like this:
 
-    BinaryDelta create path/to/old/MyApp.app path/to/new/MyApp.app patch.delta
+```sh
+BinaryDelta create path/to/old/MyApp.app path/to/new/MyApp.app patch.delta
+```
 
 To verify that your generated patch applies correctly:
 
-    BinaryDelta apply path/to/old/MyApp.app path/to/patched/MyApp.app patch.delta
+```sh
+BinaryDelta apply path/to/old/MyApp.app path/to/patched/MyApp.app patch.delta
+```
 
 Version 2 patches created by BinaryDelta are not backwards compatible with Sparkle 1.9 or earlier. Pass `--version=1` when creating patches only if you want old versions to apply them.
 
@@ -33,29 +37,31 @@ Version 2 patches created by BinaryDelta are not backwards compatible with Spark
 
 [Sign each `.delta` file](/documentation/#segue-for-security-concerns) and add an enclosure to your appcast's `<item>` in `<sparkle:deltas>` for each `.delta` file:
 
-    <item>
-       <title>Version 2.0 </title>
-       <link>https://myproductwebsite.com</link>
-       <sparkle:version>2.0</sparkle:version>
-       <description>foo bar baz</description>
-       <pubDate>Wed, 09 Jan 2006 19:20:11 +0000</pubDate>
-       <enclosure url="http://you.com/2.0_full.zip"
-                  length="123"
+```xml
+<item>
+   <title>Version 2.0 </title>
+   <link>https://myproductwebsite.com</link>
+   <sparkle:version>2.0</sparkle:version>
+   <description>foo bar baz</description>
+   <pubDate>Wed, 09 Jan 2006 19:20:11 +0000</pubDate>
+   <enclosure url="http://you.com/2.0_full.zip"
+              length="123"
+              type="application/octet-stream"
+              sparkle:edSignature="..." />
+   <sparkle:deltas>
+       <enclosure url="http://you.com/1.5-2.0.delta"
+                  sparkle:deltaFrom="1.5"
+                  length="1485"
                   type="application/octet-stream"
                   sparkle:edSignature="..." />
-       <sparkle:deltas>
-           <enclosure url="http://you.com/1.5-2.0.delta"
-                      sparkle:deltaFrom="1.5"
-                      length="1485"
-                      type="application/octet-stream"
-                      sparkle:edSignature="..." />
-           <enclosure url="http://you.com/1.6-2.0.delta"
-                      sparkle:deltaFrom="1.6"
-                      length="1428"
-                      type="application/octet-stream"
-                      sparkle:edSignature="..." />
-       </sparkle:deltas>
-    </item>
+       <enclosure url="http://you.com/1.6-2.0.delta"
+                  sparkle:deltaFrom="1.6"
+                  length="1428"
+                  type="application/octet-stream"
+                  sparkle:edSignature="..." />
+   </sparkle:deltas>
+</item>
+```
 
 ### Tips for Improving Download Size & Performance
 
@@ -64,4 +70,3 @@ We recommend reading Apple's article on [reducing the download size for iOS app 
 * Do not make unnecessary modifications to files. Compare the contents of the prior and new versions of your app and verify that you've only changed what you expect within your app bundle. Running `BinaryDelta --verbose` will show a diff of what has changed.
 * Content that you expect to change in an update should be stored in separate files from content that you don't expect to change. This reduces the size of the delta update and increases its install speed.
 * Avoid renaming files or folders.
-

--- a/documentation/eddsa-migration/index.md
+++ b/documentation/eddsa-migration/index.md
@@ -39,10 +39,14 @@ Then we recommend migrating in two steps.
 
 First, ship a new update using Sparkle 1.27 or later that specifies both DSA and EdDSA public keys (`SUPublicDSAKeyFile` and `SUPublicEDKey`) and signatures in your appcast (`sparkle:dsaSignature` and `sparkle:edSignature`). For example, the appcast item enclosure may look similar to:
 
-    <enclosure url="http://sparkle-project.org/myupdate.zip" sparkle:version="2" type="application/octet-stream" sparkle:dsaSignature="MCwCFAdLjBvvjJN0fnfMnn7BCl650VqNAhR+XuFABVK2y8zJn/oKtC1sv58ySQ==" sparkle:edSignature="ify59pDIuduaZcLnLvQjGqNQIAqi4dVgeA3L/e7I7xaqn9pVdiVZH7Na3v+Gp4ElAKJfX4Pfq8cgElfXmZc4Cg==" length="1879795" />
+```xml
+<enclosure url="http://sparkle-project.org/myupdate.zip" sparkle:version="2" type="application/octet-stream" sparkle:dsaSignature="MCwCFAdLjBvvjJN0fnfMnn7BCl650VqNAhR+XuFABVK2y8zJn/oKtC1sv58ySQ==" sparkle:edSignature="ify59pDIuduaZcLnLvQjGqNQIAqi4dVgeA3L/e7I7xaqn9pVdiVZH7Na3v+Gp4ElAKJfX4Pfq8cgElfXmZc4Cg==" length="1879795" />
+```
 
 Once all of your users are running a version of your application with these new updates, you can then ship a new update that drops the DSA public keys and signatures in your appcast. Your new appcast item enclosure may look like:
 
-    <enclosure url="http://sparkle-project.org/myupdate.zip" sparkle:version="2" type="application/octet-stream" sparkle:edSignature="ify59pDIuduaZcLnLvQjGqNQIAqi4dVgeA3L/e7I7xaqn9pVdiVZH7Na3v+Gp4ElAKJfX4Pfq8cgElfXmZc4Cg==" length="1879795" />
+```xml
+<enclosure url="http://sparkle-project.org/myupdate.zip" sparkle:version="2" type="application/octet-stream" sparkle:edSignature="ify59pDIuduaZcLnLvQjGqNQIAqi4dVgeA3L/e7I7xaqn9pVdiVZH7Na3v+Gp4ElAKJfX4Pfq8cgElfXmZc4Cg==" length="1879795" />
+```
 
 You may be able to [upgrade using new appcasts](/documentation/publishing#upgrading-to-newer-features) to expedite this process.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -135,7 +135,9 @@ If you update regular app bundles and you have set up EdDSA signatures, you can 
   1. Build your app and compress it (e.g. in a DMG/ZIP/tar.bz2 archive), and put the archive in a new folder. This folder will be used to store all your future updates.
   2. Run `generate_appcast` tool from Sparkle's distribution archive specifying the path to the folder with update archives. Allow it to access the Keychain if it asks for it (it's needed to generate signatueres in the appcast).
 
-        ./bin/generate_appcast /path/to/your/updates_folder/
+    ```sh
+    ./bin/generate_appcast /path/to/your/updates_folder/
+    ```
 
   3. The tool will generate the appcast file (using filename from [`SUFeedURL`](/documentation/customization/)) and also [`*.delta` update](/documentation/delta-updates/) files for faster incremental updates. Upload your archives, the delta updates, and the appcast to your server.
 

--- a/documentation/preferences-ui/index.md
+++ b/documentation/preferences-ui/index.md
@@ -37,9 +37,11 @@ Follow directions similar to [Enable automatic checking](#enable-automatic-check
 
 These directions do not work for non-app bundles, as the updater you add to the nib will be the `sharedUpdater` for the application bundle. To be able to bind to the updater for your bundle, you can add the following accessor to your preferences controller (the owner of the nib):
 
-    - (SUUpdater *)updater {
-        return [SUUpdater updaterForBundle:[NSBundle bundleForClass:[self class]]];
-    }
+```objc
+- (SUUpdater *)updater {
+    return [SUUpdater updaterForBundle:[NSBundle bundleForClass:[self class]]];
+}
+```
 
 Then just bind the controls to the File's Owner, and start the Model Key Path with updater., e.g. updater.automaticallyChecksForUpdates.
 

--- a/documentation/programatic-setup/index.md
+++ b/documentation/programatic-setup/index.md
@@ -8,23 +8,25 @@ title: Setting up Sparkle programmatically
 
 Here is an example of creating an updater in Sparkle 2 (beta) with Cocoa programmatically. It hooks up a menu item's target/action for checking for updates.
 
-    import Cocoa
-    import Sparkle
+```swift
+import Cocoa
+import Sparkle
 
-    @NSApplicationMain
-    @objc class AppDelegate: NSObject, NSApplicationDelegate {
-        @IBOutlet var checkForUpdatesMenuItem: NSMenuItem! // Hooked up in Interface Builder
-        
-        let updaterController = SPUStandardUpdaterController(startingUpdater: false, updaterDelegate: nil, userDriverDelegate: nil)
-        
-        func applicationDidFinishLaunching(_ notification: Notification) {
-            checkForUpdatesMenuItem.target = updaterController
-            checkForUpdatesMenuItem.action = #selector(SPUStandardUpdaterController.checkForUpdates(_:))
-            
-            // SPUStandardUpdaterController was instantiated by not starting the updater automatically
-            updaterController.startUpdater()
-        }
+@NSApplicationMain
+@objc class AppDelegate: NSObject, NSApplicationDelegate {
+    @IBOutlet var checkForUpdatesMenuItem: NSMenuItem! // Hooked up in Interface Builder
+
+    let updaterController = SPUStandardUpdaterController(startingUpdater: false, updaterDelegate: nil, userDriverDelegate: nil)
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        checkForUpdatesMenuItem.target = updaterController
+        checkForUpdatesMenuItem.action = #selector(SPUStandardUpdaterController.checkForUpdates(_:))
+
+        // SPUStandardUpdaterController was instantiated by not starting the updater automatically
+        updaterController.startUpdater()
     }
+}
+```
 
 In Sparkle 2 you can also choose to instantiate and use `SPUUpdater` directly instead of the `SPUStandardUpdaterController` wrapper if you need more control over your user interface or what bundle to update.
 

--- a/documentation/publishing/index.md
+++ b/documentation/publishing/index.md
@@ -13,7 +13,9 @@ Put a copy of your .app (with the same name as the version it's replacing) in a 
 
 Make sure symlinks are preserved when you create the archive. macOS frameworks use symlinks, and their code signature will be broken if your archival tool follows symlinks instead of archiving them. For creating zip archives, `ditto` can be used (behaves the same as Finder's Compress option):
 
-    ditto -c -k --sequesterRsrc --keepParent <src_path_to_app> <zip_dest>
+```sh
+ditto -c -k --sequesterRsrc --keepParent <src_path_to_app> <zip_dest>
+```
 
 If you can't use regular app bundles, you can also create an Installer .pkg with the same name as your app and put that .pkg in one of the aforementioned archive formats. By default Sparkle launches Installer without a GUI. If instead of .pkg extension you use .sparkle_interactive.pkg, then installation will run with a GUI and ask user to confirm every step.
 
@@ -25,7 +27,9 @@ Signatures are automatically generated when you make an appcast using `generate_
 
 To manually generate signatures for your updates, Sparkle includes a tool to help you make a EdDSA signature of the archive. From the Sparkle distribution:
 
-    ./bin/sign_update path_to_your_update.zip
+```sh
+./bin/sign_update path_to_your_update.zip
+```
 
 The output will be an XML fragment with your update's EdDSA signature and (optional) file size; you'll add this attribute to your enclosure in the next step.
 
@@ -35,19 +39,21 @@ Since 10.11, macOS has [App Transport Security](//developer.apple.com/library/pr
 
 You need to create an `<item>` for your update in your appcast. See the [sample appcast](/files/sparkletestcast.xml) for an example. Here's a template you might use:
 
-    <item>
-        <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
-        <link>https://myproductwebsite.com</link>
-        <sparkle:version>2.0</sparkle:version>
-        <sparkle:releaseNotesLink>
-            https://example.com/release_notes/app_2.0.html
-        </sparkle:releaseNotesLink>
-        <pubDate>Mon, 05 Oct 2015 19:20:11 +0000</pubDate>
-        <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
-                   sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
-                   length="1623481"
-                   type="application/octet-stream" />
-    </item>
+```xml
+<item>
+    <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
+    <link>https://myproductwebsite.com</link>
+    <sparkle:version>2.0</sparkle:version>
+    <sparkle:releaseNotesLink>
+        https://example.com/release_notes/app_2.0.html
+    </sparkle:releaseNotesLink>
+    <pubDate>Mon, 05 Oct 2015 19:20:11 +0000</pubDate>
+    <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
+                sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
+                length="1623481"
+                type="application/octet-stream" />
+</item>
+```
 
 Test your update, and you're done!
 
@@ -63,20 +69,22 @@ If you use internal build numbers for your `CFBundleVersion` key and a human-rea
 
 Set the `sparkle:version` element in your item to the internal, machine-readable version (ie: "1248"). Then set a `sparkle:shortVersionString` element on in your item to the human-readable version (ie: "1.5.1"). For example:
 
-    <item>
-        <title>Version 1.5.1 (bug fixes)</title>
-        <link>https://myproductwebsite.com</link>
-        <sparkle:version>1248</sparkle:version>
-        <sparkle:shortVersionString>1.5.1</sparkle:shortVersionString>
-        <sparkle:releaseNotesLink>
-            https://example.com/release_notes/app_2.0.html
-        </sparkle:releaseNotesLink>
-        <pubDate>Mon, 05 Oct 2015 19:20:11 +0000</pubDate>
-        <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
-                   sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
-                   length="1623481"
-                   type="application/octet-stream" />
-    </item>
+```xml
+<item>
+    <title>Version 1.5.1 (bug fixes)</title>
+    <link>https://myproductwebsite.com</link>
+    <sparkle:version>1248</sparkle:version>
+    <sparkle:shortVersionString>1.5.1</sparkle:shortVersionString>
+    <sparkle:releaseNotesLink>
+        https://example.com/release_notes/app_2.0.html
+    </sparkle:releaseNotesLink>
+    <pubDate>Mon, 05 Oct 2015 19:20:11 +0000</pubDate>
+    <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
+                sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
+                length="1623481"
+                type="application/octet-stream" />
+</item>
+```
 
 Note that the internal version number (`CFBundleVersion` and `sparkle:version`) is intended to be machine-readable and is not generally suitable for formatted text or git changeset IDs.
 
@@ -86,12 +94,14 @@ If an update to your application raises the required version of macOS, you can o
 
 Add a `sparkle:minimumSystemVersion` child to the `<item>` in question specifying the required system version, such as "10.11.0" (be sure to specify a three-part version in form of *major.minor.patch*):
 
-    <item>
-        <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
-        <link>https://myproductwebsite.com</link>
-        <sparkle:version>2.0</sparkle:version>
-        <sparkle:minimumSystemVersion>10.11.0</sparkle:minimumSystemVersion>
-    </item>
+```xml
+<item>
+    <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
+    <link>https://myproductwebsite.com</link>
+    <sparkle:version>2.0</sparkle:version>
+    <sparkle:minimumSystemVersion>10.11.0</sparkle:minimumSystemVersion>
+</item>
+```
 
 Note that Sparkle only works with macOS 10.9 or later (macOS 10.11 or later for Sparkle 2), so that's the lowest minimum version you can use.
 
@@ -105,12 +115,14 @@ If an update to your application is a major or paid upgrade, you may want to pre
 
 Add a `sparkle:minimumAutoupdateVersion` child to the `<item>` in question specifying the major update's `<CFBundleVersion>`, such as "2.0":
 
-    <item>
-        <title>Version 2.1 (2 bugs fixed; 3 new features)</title>
-        <link>https://myproductwebsite.com</link>
-        <sparkle:version>2.1</sparkle:version>
-        <sparkle:minimumAutoupdateVersion>2.0</sparkle:minimumAutoupdateVersion>
-    </item>
+```xml
+<item>
+    <title>Version 2.1 (2 bugs fixed; 3 new features)</title>
+    <link>https://myproductwebsite.com</link>
+    <sparkle:version>2.1</sparkle:version>
+    <sparkle:minimumAutoupdateVersion>2.0</sparkle:minimumAutoupdateVersion>
+</item>
+```
 
 If this value is set, it indicates the lowest version that can automatically update to the version referenced by the appcast (i.e. without showing the _update available_ GUI). Apps with a lower `CFBundleVersion` will always see the _update available_ GUI, regardless of their `SUAutomaticallyUpdate` user defaults setting.
 
@@ -122,30 +134,34 @@ Additionally in Sparkle 2:
 
 If you want to provide a download link, instead of having Sparkle download and install the update itself, you can omit the `<enclosure>` tag and add `<sparkle:version>` and `<link>` tags. For example:
 
-    <item>
-      <title>Version 1.2.4</title>
-      <sparkle:version>1.2.4</sparkle:version>
-      <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
-      <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
-      <link>https://myproductwebsite.com</link>
-    </item>
+```xml
+<item>
+    <title>Version 1.2.4</title>
+    <sparkle:version>1.2.4</sparkle:version>
+    <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
+    <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
+    <link>https://myproductwebsite.com</link>
+</item>
+```
 
 Apps that use Sparkle 2 can use the new `<sparkle:informationalUpdate>` tag instead of omitting the `<enclosure>` tag. This also allows specifying which application versions should see an update as only informational:
 
-    <item>
-      <title>Version 1.2.4</title>
-      <sparkle:version>1.2.4</sparkle:version>
-      <sparkle:informationalUpdate>
-        <sparkle:version>1.2.3</sparkle:version>
-      </sparkle:informationalUpdate>
-      <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
-      <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
-      <link>https://myproductwebsite.com</link>
-      <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
-                   sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
-                   length="1623481"
-                   type="application/octet-stream" />
-    </item>
+```xml
+<item>
+    <title>Version 1.2.4</title>
+    <sparkle:version>1.2.4</sparkle:version>
+    <sparkle:informationalUpdate>
+    <sparkle:version>1.2.3</sparkle:version>
+    </sparkle:informationalUpdate>
+    <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
+    <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
+    <link>https://myproductwebsite.com</link>
+    <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
+                sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
+                length="1623481"
+                type="application/octet-stream" />
+</item>
+```
 
 In this example, because `<sparkle:version>1.2.3</sparkle:version>` is specified in `<sparkle:informationalUpdate>`, only version `1.2.3` will see this update as an informational one with a download link. Other versions of the application will see this as an update they can install from inside the application. You can add more children to specify, for example, that version 1.2.2 should also see the update as informational. If you do not specify any children to `<sparkle:informationalUpdate>`, then the update is informational to all versions.
 
@@ -153,35 +169,39 @@ In this example, because `<sparkle:version>1.2.3</sparkle:version>` is specified
 
 Updates that are marked critical are shown to the user more promptly and do not let the user skip them. You can use the `<sparkle:criticalUpdate>` tag. For example, if version 1.2.4 is a critical update:
 
-    <item>
-      <title>Version 1.2.4</title>
-      <sparkle:version>1.2.4</sparkle:version>
-      <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
-      <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
-      <link>https://myproductwebsite.com</link>
-      <sparkle:tags>
-        <sparkle:criticalUpdate></sparkle:criticalUpdate>
-      </sparkle:tags>
-      <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
-                   sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
-                   length="1623481"
-                   type="application/octet-stream" />
-    </item>
+```xml
+<item>
+    <title>Version 1.2.4</title>
+    <sparkle:version>1.2.4</sparkle:version>
+    <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
+    <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
+    <link>https://myproductwebsite.com</link>
+    <sparkle:tags>
+    <sparkle:criticalUpdate></sparkle:criticalUpdate>
+    </sparkle:tags>
+    <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
+                sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
+                length="1623481"
+                type="application/octet-stream" />
+</item>
+```
 
 Apps that use Sparkle 2 can use the newer `<sparkle:criticalUpdate>` tag that is a top-level element and not placed within `<sparkle:tags>`. Additionally, the version that was last critical can be specified. For example, when 1.2.5 is released you can specify that only versions less than 1.2.4 should treat this as a critical update:
 
-    <item>
-      <title>Version 1.2.5</title>
-      <sparkle:version>1.2.5</sparkle:version>
-      <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
-      <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
-      <link>https://myproductwebsite.com</link>
-      <sparkle:criticalUpdate sparkle:version="1.2.4"></sparkle:criticalUpdate>
-      <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
-                   sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
-                   length="1623481"
-                   type="application/octet-stream" />
-    </item>
+```xml
+<item>
+    <title>Version 1.2.5</title>
+    <sparkle:version>1.2.5</sparkle:version>
+    <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
+    <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
+    <link>https://myproductwebsite.com</link>
+    <sparkle:criticalUpdate sparkle:version="1.2.4"></sparkle:criticalUpdate>
+    <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
+                sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
+                length="1623481"
+                type="application/octet-stream" />
+</item>
+```
 
 ## Phased group rollouts
 
@@ -193,18 +213,20 @@ This feature requires:
 
 For example:
 
-    <item>
-      <title>Version 1.2.5</title>
-      <sparkle:version>1.2.5</sparkle:version>
-      <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
-      <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
-      <link>https://myproductwebsite.com</link>
-      <sparkle:phasedRolloutInterval>86400</sparkle:phasedRolloutInterval>
-      <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
-                   sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
-                   length="1623481"
-                   type="application/octet-stream" />
-    </item>
+```xml
+<item>
+    <title>Version 1.2.5</title>
+    <sparkle:version>1.2.5</sparkle:version>
+    <sparkle:releaseNotesLink>https://example.com/release_notes_test.html</sparkle:releaseNotesLink>
+    <pubDate>Mon, 28 Jan 2013 14:30:00 +0500</pubDate>
+    <link>https://myproductwebsite.com</link>
+    <sparkle:phasedRolloutInterval>86400</sparkle:phasedRolloutInterval>
+    <enclosure url="https://example.com/downloads/app.zip.or.dmg.or.tar.etc"
+                sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="
+                length="1623481"
+                type="application/octet-stream" />
+</item>
+```
 
 This update item specifies the `phasedRolloutInterval` as 86400 seconds, or 1 day. This means that there is 1 day of interval between groups. Sparkle hardcodes the number of groups to 7, so this means that the update will be rolled out completely in 7 days and an update will be rolled out to a new group each day after the `pubDate`.
 
@@ -218,19 +240,22 @@ Sparkle 2 provides specifying what channel an update is on. Examples of channels
 
 Updates are posted on the default channel unless specified otherwise. This example shows an update posted on the "beta" channel:
 
-
-    <item>
-      <title>Version 2.0 (Beta 1)</title>
-      <sparkle:channel>beta</sparkle:channel>
-      <sparkle:version>20001</sparkle:version>
-      <sparkle:shortVersionString>2.0b1</sparkle:shortVersionString>
-    </item>
+```xml
+<item>
+    <title>Version 2.0 (Beta 1)</title>
+    <sparkle:channel>beta</sparkle:channel>
+    <sparkle:version>20001</sparkle:version>
+    <sparkle:shortVersionString>2.0b1</sparkle:shortVersionString>
+</item>
+```
 
 Only updaters that are allowed to look in the beta channel can find this update. An updater may use `-[SPUUpdaterDelegate allowedChannelsForUpdater:]` to find this update in addition to updates that are on the default channel:
 
-    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
-        return Set(["beta"])
-    }
+```swift
+func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+    return Set(["beta"])
+}
+```
 
 Note that an updater cannot exclude itself from the default channel. Channels are intended to be a way to branch off updates to your application until newer updates are ready to come back to the default channel.
 
@@ -247,9 +272,11 @@ The recommended way to change the feed URL programatically is using `-[SUUpdater
 
 Here is an example:
 
-    func feedURLString(for updater: SPUUpdater) -> String? {
-        return UserDefaults.standard.bool(forKey: "beta") ? BETA_FEED_URL_STRING : STABLE_FEED_URL_STRING
-    }
+```swift
+func feedURLString(for updater: SPUUpdater) -> String? {
+    return UserDefaults.standard.bool(forKey: "beta") ? BETA_FEED_URL_STRING : STABLE_FEED_URL_STRING
+}
+```
 
 Sparkle also has `-setFeedURL:` or `feedURL` property on the updater which we do not recommend using due to race conditions and user defaults permanence. If you wish to migrate away from this API, you should set the feed URL to nil using this API to clear out any custom feed you have previously set in the bundle's user defaults, so Sparkle doesn't automatically read it.
 
@@ -265,17 +292,19 @@ A second approach is migrating to a new `SUFeedURL` in your new application's `I
 
 Instead of linking external release notes using the `<sparkle:releaseNotesLink>` element, you can also embed the release notes directly in the appcast item, inside a `<description>` element. If you wrap it in `<![CDATA[ ... ]]>`, you can use unescaped HTML.
 
-    <item>
-        <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
-        <link>https://myproductwebsite.com</link>
-        <sparkle:version>2.0</sparkle:version>
-        <description><![CDATA[
-            <h2>New Features</h2>
-            ...
-        ]]>
-        </description>
+```xml
+<item>
+    <title>Version 2.0 (2 bugs fixed; 3 new features)</title>
+    <link>https://myproductwebsite.com</link>
+    <sparkle:version>2.0</sparkle:version>
+    <description><![CDATA[
+        <h2>New Features</h2>
         ...
-    </item>
+    ]]>
+    </description>
+    ...
+</item>
+```
 
 You can embed just marked up text (it'll be displayed using standard system font), or a full document with `<!DOCTYPE html><style>`, etc.
 
@@ -292,39 +321,43 @@ Use the `xml:lang` attribute with the appropriate two-letter country code for ea
 
 You can define your own top level elements in the appcast item using your own custom XML namespace (specified by `xmlns`). Here is an example defining `xmlns:myapp` namespace and creating a `myapp:messageOfTheDay` element:
 
-    <?xml version="1.0" encoding="utf-8"?>
-    <rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:myapp="https://myproductpage.com/" xmlns:dc="http://purl.org/dc/elements/1.1/">
-      <channel>
-        <title>My App Changelog</title>
-        <language>en</language>
-          <item>
-            <title>Version 2.0</title>
-            <myapp:messageOfTheDay>Tip: you can do X by using Y</myapp:messageOfTheDay>
-            <!-- The rest of the feed item -->
-          </item>
-      </channel>
-    </rss>
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:myapp="https://myproductpage.com/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+    <title>My App Changelog</title>
+    <language>en</language>
+        <item>
+        <title>Version 2.0</title>
+        <myapp:messageOfTheDay>Tip: you can do X by using Y</myapp:messageOfTheDay>
+        <!-- The rest of the feed item -->
+        </item>
+    </channel>
+</rss>
+```
 
 In Sparkle 2, one place to parse this custom property is in `-[SPUUpdaterDelegate updaterDidNotFindUpdate:error:]`. Here's an example:
 
-    func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
-        let userInfo = (error as NSError).userInfo
-        guard
-            let latestUpdateItem = userInfo[SPULatestAppcastItemFoundKey] as? SUAppcastItem,
-            let userInitiated = userInfo[SPUNoUpdateFoundUserInitiatedKey] as? Bool,
-            let reasonValue = userInfo[SPUNoUpdateFoundReasonKey] as? OSStatus,
-            let reason = SPUNoUpdateFoundReason(rawValue: reasonValue),
-            let messageOfTheDay = latestUpdateItem.propertiesDictionary["myapp:messageOfTheDay"] as? String else {
-            return
-        }
-        
-        if !userInitiated &&
-            !latestUpdateItem.isMajorUpgrade &&
-            !latestUpdateItem.isCriticalUpdate &&
-            (reason == .onLatestVersion || reason == .onNewerThanLatestVersion) {
-            print(messageOfTheDay)
-        }
+```swift
+func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: Error) {
+    let userInfo = (error as NSError).userInfo
+    guard
+        let latestUpdateItem = userInfo[SPULatestAppcastItemFoundKey] as? SUAppcastItem,
+        let userInitiated = userInfo[SPUNoUpdateFoundUserInitiatedKey] as? Bool,
+        let reasonValue = userInfo[SPUNoUpdateFoundReasonKey] as? OSStatus,
+        let reason = SPUNoUpdateFoundReason(rawValue: reasonValue),
+        let messageOfTheDay = latestUpdateItem.propertiesDictionary["myapp:messageOfTheDay"] as? String else {
+        return
     }
+    
+    if !userInitiated &&
+        !latestUpdateItem.isMajorUpgrade &&
+        !latestUpdateItem.isCriticalUpdate &&
+        (reason == .onLatestVersion || reason == .onNewerThanLatestVersion) {
+        print(messageOfTheDay)
+    }
+}
+```
 
 ## Alternate download locations for other operating systems
 
@@ -332,6 +365,8 @@ Sparkle is available for [Windows](http://winsparkle.org).
 
 To keep the appcast file compatible with the standard Sparkle implementation, a new tag has to be used for cross platform support. It is suggested to use the following to specify downloads for non macOS systems:
 
-    <sparkle:enclosure sparkle:os="os_name" ...>
+```xml
+<sparkle:enclosure sparkle:os="os_name" ...>
+```
 
 Replace _os_name_ with either "windows" or "linux", respectively (mind the lower case!). Feel free to add other OS names as needed.

--- a/documentation/sandboxing/index.md
+++ b/documentation/sandboxing/index.md
@@ -27,7 +27,7 @@ The Installer Launcher Service is required. This service bundles a copy of Spark
 
 To optimize for space, a sandboxed application that uses this service may optionally choose to remove the helper tools from the `Sparkle.framework` and re-sign the framework:
 
-```
+```sh
 rm -f Sparkle.framework/Autoupdate
 rm -f Sparkle.framework/Updater
 rm -f Sparkle.framework/Versions/A/Autoupdate
@@ -47,7 +47,7 @@ The Downloader XPC Service is optional. Use it only if your sandboxed applicatio
 
 The Installer Connection & Status Services are optional (as of changes integrated on [April 4, 2021](https://github.com/sparkle-project/Sparkle/pull/1812)). Instead of using these services, we recommend adding the following entitlement to your sandboxed application:
 
-```
+```xml
 <key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 <array>
     <string>$(PRODUCT_BUNDLE_IDENTIFIER)-spks</string>
@@ -70,7 +70,7 @@ Then you can probably skip onto [Adding the XPC Services](#adding-the-xpc-servic
 
 Otherwise if you use alternate methods of distributing your application, or you need to use a different certificate for development, you can code sign these services by running the `bin/codesign_xpc_service` script. For example:
 
-```
+```sh
 ./bin/codesign_xpc_service "Developer ID Application" XPCServices/org.sparkle-project.InstallerLauncher.xpc XPCServices/org.sparkle-project.Downloader.xpc
 ```
 

--- a/documentation/sparkle-cli/index.md
+++ b/documentation/sparkle-cli/index.md
@@ -71,7 +71,7 @@ Options:
 
 One example is I updated an application on my machine I knew was out of date by running:
 
-```
+```sh
 ./sparkle.app/Contents/MacOS/sparkle --check-immediately /Applications/Hex\ Fiend.app/
 ```
 

--- a/documentation/upgrading/index.md
+++ b/documentation/upgrading/index.md
@@ -111,7 +111,9 @@ Sparkle has kept the same API since the "classic" version 1.5. It should be a dr
 
 To avoid sending incompatible app to users on macOS 10.6 or older, add to your appcast `<item>`:
 
-    <sparkle:minimumSystemVersion>10.7</sparkle:minimumSystemVersion>
+```xml
+<sparkle:minimumSystemVersion>10.7</sparkle:minimumSystemVersion>
+```
 
 ### 64-bit, ARC or manual memory management
 


### PR DESCRIPTION
Easier to review with [whitespace changes hidden](https://github.com/sparkle-project/sparkle-project.github.io/pull/77/files?diff=unified&w=1). I wasn't able to test locally, though, because the layouts didn't load, and I don't know if that's just a problem with my local Jekyll, or what.

```
$ jekyll serve
Configuration file: none
            Source: /Users/zev/Projects/sparkle-project.github.io/documentation
       Destination: /Users/zev/Projects/sparkle-project.github.io/documentation/_site
 Incremental build: disabled. Enable with --incremental
      Generating... 
     Build Warning: Layout 'documentation' requested in index.md does not exist.
     Build Warning: Layout 'documentation' requested in eddsa-migration/index.md does not exist.
     Build Warning: Layout 'documentation' requested in system-profiling/index.md does not exist.
     Build Warning: Layout 'documentation' requested in customization/index.md does not exist.
     Build Warning: Layout 'documentation' requested in security/index.md does not exist.
     Build Warning: Layout 'documentation' requested in preferences-ui/index.md does not exist.
     Build Warning: Layout 'documentation' requested in sandboxing/index.md does not exist.
     Build Warning: Layout 'documentation' requested in programatic-setup/index.md does not exist.
     Build Warning: Layout 'documentation' requested in app-transport-security/index.md does not exist.
     Build Warning: Layout 'documentation' requested in sparkle-cli/index.md does not exist.
     Build Warning: Layout 'documentation' requested in upgrading/index.md does not exist.
     Build Warning: Layout 'documentation' requested in package-updates/index.md does not exist.
     Build Warning: Layout 'documentation' requested in delta-updates/index.md does not exist.
     Build Warning: Layout 'documentation' requested in bundles/index.md does not exist.
     Build Warning: Layout 'documentation' requested in publishing/index.md does not exist.
                    done in 0.317 seconds.
 Auto-regeneration: enabled for '/Users/zev/Projects/sparkle-project.github.io/documentation'
    Server address: http://127.0.0.1:4000
  Server running... press ctrl-c to stop.
[2021-08-15 15:19:30] ERROR `/favicon.ico' not found.
[2021-08-15 15:19:51] ERROR `/documentation/publishing/' not found.
[2021-08-15 15:19:52] ERROR `/documentation/publishing/' not found.
[2021-08-15 15:19:54] ERROR `/documentation/publishing/' not found.
```

```
$ jekyll --version
jekyll 4.2.0
$ ruby --version
ruby 2.6.3p62 (2019-04-16 revision 67580) [x86_64-darwin19]
```