### PR TITLE
Recommend using bare package installations first

### DIFF
--- a/documentation/package-updates/index.md
+++ b/documentation/package-updates/index.md
@@ -7,15 +7,15 @@ title: Package Updates
 
 Package installation allows Sparkle to update your application by downloading and installing a package, `pkg`, or multi-package, `mpkg` usually without user interaction except for asking for an administrator password.
 
+### Automatic Bare Installation
+
+Sparkle supports serving and signing flat `*.pkg` or `*.mpkg` packages directly without having to zip or archive them. This requires users from old versions of your application to be using [Sparkle 1.26 or later](/documentation/upgrading/).
+
 ### Automatic Archived Installation
 
 An automatic archived installation occurs when Sparkle finds a `*.pkg` or `*.mpkg` file in the root of the download archive. [Older versions](/documentation/upgrading/) of Sparkle required the filename to be `*.sparkle_guided.pkg` to perform an automatic installation, so you may want to keep that name until majority of your users update to your application with Sparkle 1.16 or later.
 
 **Note**: For Sparkle 2, you must add `sparkle:installationType="package"` to your appcast item for updating automatic packages that are archived.
-
-### Automatic Bare Installation
-
-Sparkle [1.26 or later](/documentation/upgrading/) supports serving and signing flat `*.pkg` or `*.mpkg` packages directly without having to zip or archive them. You will want to keep archiving them however until majority of your users update to your application with a version of Sparkle that supports this.
 
 ### Interactive Archived UI Installation
 


### PR DESCRIPTION
Documentation guide should cater to newer users and new functionality first most.