### PR TITLE
Recommend zip and tarball formats more strongly

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -123,7 +123,7 @@ If you distribute your app as a ZIP or a tar archive (due to [app translocation]
 
 If your app is running from a read-only mount, you can encourage (if you so desire) your user to move the app into /Applications. Some frameworks, although not officially sanctioned here, exist for this purpose. Note Sparkle will not by default automatically disturb your user if an update cannot be performed.
 
-Sparkle supports updating from ZIP archives, tarballs, disk images (DMGs), and installer packages. While you can reuse the same archive for distribution of your app on your website, we recommend serving ZIPs or tarballs for updates because they are the fastest and most reliable formats for Sparkle. Disk images (DMGs) can be up to 20x slower to extract and installer packages should rarely be used.
+Sparkle supports updating from ZIP archives, tarballs, disk images (DMGs), and installer packages. While you can reuse the same archive for distribution of your app on your website, we recommend serving ZIPs or tarballs for updates because they are the fastest and most reliable formats for Sparkle. Disk images (DMGs) can be significantly slower to extract and HFS+ formatted disk images are even slower than APFS formatted images (which require macOS 10.13 or later). Installer packages should rarely be used for distribution.
 
 ### 5. Publish your appcast
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -123,9 +123,7 @@ If you distribute your app as a ZIP or a tar archive (due to [app translocation]
 
 If your app is running from a read-only mount, you can encourage (if you so desire) your user to move the app into /Applications. Some frameworks, although not officially sanctioned here, exist for this purpose. Note Sparkle will not by default automatically disturb your user if an update cannot be performed.
 
-Sparkle supports updating from DMG, ZIP archives, tarballs, and installer packages. While you can generally reuse the same archive for distribution of your app on your website, Sparkle favors some formats for serving updates more efficiently and reliably.
-
-For Sparkle, tarballs and ZIPs are fastest and most reliable. DMG are slowest. Installer packages should be used only if absolutely necessary (e.g. kernel extensions).
+Sparkle supports updating from ZIP archives, tarballs, disk images (DMGs), and installer packages. While you can reuse the same archive for distribution of your app on your website, we recommend serving ZIPs or tarballs for updates because they are the fastest and most reliable formats for Sparkle. Disk images (DMGs) can be up to 20x slower to extract and installer packages should rarely be used.
 
 ### 5. Publish your appcast
 
@@ -136,7 +134,7 @@ Sparkle uses appcasts to get information about software updates. An appcast is a
 
 If you update regular app bundles and you have set up EdDSA signatures, you can use a tool to generate appcasts automatically:
 
-  1. Build your app and compress it (e.g. in a DMG/ZIP/tar.bz2 archive), and put the archive in a new folder. This folder will be used to store all your future updates.
+  1. Build your app and compress it (e.g. in a ZIP/tar.bz2/DMG archive), and put the archive in a new folder. This folder will be used to store all your future updates.
   2. Run `generate_appcast` tool from Sparkle's distribution archive specifying the path to the folder with update archives. Allow it to access the Keychain if it asks for it (it's needed to generate signatueres in the appcast).
 
         ./bin/generate_appcast /path/to/your/updates_folder/


### PR DESCRIPTION
Because disk images are very slow / unreliable and package installers should be used in rare cases.