### PR TITLE
Add documentation clarification

### DIFF
--- a/documentation/index.md
+++ b/documentation/index.md
@@ -123,7 +123,7 @@ If you distribute your app as a ZIP or a tar archive (due to [app translocation]
 
 If your app is running from a read-only mount, you can encourage (if you so desire) your user to move the app into /Applications. Some frameworks, although not officially sanctioned here, exist for this purpose. Note Sparkle will not by default automatically disturb your user if an update cannot be performed.
 
-Sparkle supports updating from ZIP archives, tarballs, disk images (DMGs), and installer packages. While you can reuse the same archive for distribution of your app on your website, we recommend serving ZIPs or tarballs for updates because they are the fastest and most reliable formats for Sparkle. Disk images (DMGs) can be significantly slower to extract and HFS+ formatted disk images are even slower than APFS formatted images (which require macOS 10.13 or later). Installer packages should rarely be used for distribution.
+Sparkle supports updating from ZIP archives, tarballs, disk images (DMGs), and installer packages. While you can reuse the same archive for distribution of your app on your website, we recommend serving ZIPs or tarballs (e.g. tar.bz2) for updates because they are the fastest and most reliable formats for Sparkle. Disk images (DMGs) can be significantly slower to extract programmatically and HFS+ formatted disk images are even slower than APFS formatted images (which require macOS 10.13 or later). Installer packages should rarely be used for distribution.
 
 ### 5. Publish your appcast
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -130,7 +130,7 @@ Sparkle supports updating from ZIP archives, tarballs, disk images (DMGs), and i
 Sparkle uses appcasts to get information about software updates. An appcast is an RSS feed with some extra information for Sparkle's purposes.
 
   * Add a [`SUFeedURL`](/documentation/customization/) property to your `Info.plist`; set its value to a URL where your appcast will be hosted, e.g. `https://yourcompany.example.com/appcast.xml`. We [strongly encourage you to use HTTPS](/documentation/app-transport-security/) URLs for the appcast.
-  * Note that your app bundle must have a [properly formatted `CFBundleVersion`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion) key in your `Info.plist`.
+  * Note that your app bundle must have an incrementing and [properly formatted `CFBundleVersion`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion) key in your `Info.plist`. Sparkle uses this to compare and determine the latest version of your bundle.
 
 If you update regular app bundles and you have set up EdDSA signatures, you can use a tool to generate appcasts automatically:
 

--- a/documentation/sandboxing/index.md
+++ b/documentation/sandboxing/index.md
@@ -91,4 +91,4 @@ If you do not sandbox your application, we do not recommend using Sparkle's XPC 
 
 ### Testing
 
-If Xcode has issues running your application using Sparkle and its XPC Services (such as being unable to attach to the process), try editing your project's Scheme and disable *Debug XPC services used by app* or test your application detached from Xcode to see if it works there. This is an issue because the XPC Services are currently being built with the Hardened Runtime enabled which normally disallows a debugger to attach to them.
+If Xcode has issues running your application using Sparkle and its XPC Services (such as being unable to attach to the process), try editing your project's Scheme and disable *Debug XPC services used by app* or test your application detached from Xcode to see if it works there. This shouldn't be an issue in a development environment if you follow the standard workflow we suggest, but this may be needed if the XPC Service is signed with the Hardened Runtime and not with the `com.apple.security.get-task-allow` entitlement.


### PR DESCRIPTION
Clarify the purpose of requiring CFBundleVersion.

Clarify in Testing that debugging issue shouldn't happen with workflow we suggest.