### PR TITLE
Update package management details

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -83,14 +83,14 @@ samp {
       margin: 2em 0 1em 0;
     }
 
-    a.btn-cocoapods,
-    a.btn-cocoapods:hover,
-    a.btn-cocoapods:active,
-    a.btn-cocoapods:visited {
+    a.btn-setup,
+    a.btn-setup:hover,
+    a.btn-setup:active,
+    a.btn-setup:visited {
       text-decoration: none;
     }
 
-    a.btn-cocoapods {
+    a.btn-setup {
       font-size: 0.7em;
       font-weight: normal;
       letter-spacing: 1.2px;
@@ -104,7 +104,7 @@ samp {
              box-shadow: 0 14px 26px rgba(0,0,0,0.15);
     }
 
-    a.btn-cocoapods:hover {
+    a.btn-setup:hover {
       -webkit-transition: all .5s;
      -webkit-box-shadow: 0 7px 13px rgba(0,0,0,0.10);
              box-shadow: 0 7px 13px rgba(0,0,0,0.10);

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -36,6 +36,8 @@ If you use [Carthage](https://github.com/Carthage/Carthage):
     * Click on the <samp>General</samp> tab.
     * In <samp>Frameworks, Libraries, and Embedded Content</samp> section, change Sparkle.framework to <samp>Embed & Sign</samp>.
 
+  Sparkle's tools to generate and sign updates are not included and need to be grabbed from [our releases](//github.com/{{ site.github_username }}/Sparkle/releases/latest).
+
   Sparkle only supports using a `binary` origin with Carthage because Carthage strips necessary code signing information when building the project from source.
 
 If you want to add Sparkle manually:

--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@ navbar_extra_styles: navbar-home
     <p class="tag-line">Sparkle is an easy-to-use software update framework for macOS applications.</p>
     <p>
       <a class="btn-download" href="//github.com/{{ site.github_username }}/Sparkle/releases/latest" role="button">Download latest</a>
-      <a class="btn-cocoapods" href="//cocoapods.org/pods/Sparkle" role="button">CocoaPod</a>
+      <a class="btn-setup" href="documentation" role="button">Basic setup</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
Replace CocoaPods button on main webpage with link to Basic setup.

Clarify that Sparkle tools are not included in Carthage package.