### PR TITLE
Clarify “minimum system version requirements” summary

### DIFF
--- a/documentation/publishing/index.md
+++ b/documentation/publishing/index.md
@@ -106,7 +106,7 @@ Note that the internal version number (`CFBundleVersion` and `sparkle:version`) 
 
 ## Minimum system version requirements
 
-If an update to your application raises the required version of macOS, you can only offer that update to qualified users.
+If an update to your application raises the required version of macOS, you can restrict that update to qualified users.
 
 Add a `sparkle:minimumSystemVersion` child to the `<item>` in question specifying the required system version, such as "10.13.0" (be sure to specify a three-part version in form of *major.minor.patch*):
 


### PR DESCRIPTION
Change the phrase “you can only offer that update only to qualified users” to “you can restrict that update to qualified users.”

The former language implies that Sparkle prohibits offering the update to non-qualifying users, which is not accurate (until so configured). The intent is to convey that Sparkle can facilitate offering the update only to qualified users.