### PR TITLE
Update documentation for 2.9 (beta)

### DIFF
--- a/documentation/app-transport-security/index.md
+++ b/documentation/app-transport-security/index.md
@@ -5,14 +5,12 @@ title: Sparkle App Transport Security
 ---
 ## App Transport Security
 
-Apple has deprecated insecure HTTP in macOS 10.11 (El Capitan). Applications compiled with 10.11 SDK are by default **blocked from using HTTP** and will not be able to download any updates over HTTP. You **must** either:
+Apple has deprecated insecure HTTP. Applications are by default **blocked from using HTTP** and will not be able to download any updates over HTTP. You **must** either:
 
-* Switch to HTTPS entirely. Change the appcast URL in Info.plist and download URLs in the appcast to use HTTPS. This is recommended, and you can get free certificates from [Let's Encrypt](//letsencrypt.org/) or [AWS Certificate Manager](//aws.amazon.com/certificate-manager/).
+* Switch to HTTPS entirely. Make the appcast URL in Info.plist and download URLs in the appcast use HTTPS. This is recommended, and you can get free certificates from [Let's Encrypt](//letsencrypt.org/) or [AWS Certificate Manager](//aws.amazon.com/certificate-manager/).
 
 * Add an exception to Info.plist in your app if you can't stop using HTTP yet. [The exception properties are in Apple's documentation](//developer.apple.com/library/prerelease/mac/technotes/App-Transport-Security-Technote/).
 
-If you don't do this, your app will not be able to download updates on macOS El Capitan, and your users will be stuck with an old version forever.
-
-App Transport Security has other specific requirements too, so please test updating your app on 10.11 even if you already are serving over HTTPS!
+App Transport Security has other specific requirements too, so please test updating your app even if you already are serving over HTTPS!
 
 [‹ Back to documentation](/documentation/#segue-for-security-concerns)

--- a/documentation/custom-user-interfaces/index.md
+++ b/documentation/custom-user-interfaces/index.md
@@ -6,7 +6,7 @@ title: Custom User Interfaces
 
 ## Custom User Interfaces
 
-Sparkle's standard user interface handles many standard behaviors for you. However, some applications may want their own tailored user interface. Before switching to a custom UI for your updater, you should consider if your application will provide the updating functionality users want. For example, users appreciate viewing release notes when being shown a new update is available. Some users may also prefer to reduce update notifications/badges/alerts/custom UI indicators altogether by automatically downloading and installing updates in the future. You may also want to check [gentle update reminders](/documentation/gentle-reminders) for changing how Sparkle's standard update alert can be presented.
+Sparkle's standard user interface handles many standard behaviors for you. However, some applications may want their own tailored user interface. Before switching to a custom UI for your updater, you should consider if your application will provide the updating functionality users want. For example, users appreciate viewing release notes when being shown a new update is available. Some users may also prefer to reduce update notifications/badges/alerts/custom UI indicators altogether by automatically downloading and installing updates, which the standard UI provides a setting for. You may also want to check [gentle update reminders](/documentation/gentle-reminders) for changing how Sparkle's standard update alert can be presented.
 
 ### SPUUserDriver
 

--- a/documentation/customization/index.md
+++ b/documentation/customization/index.md
@@ -14,7 +14,7 @@ For example:
 
 Some of the Info.plist settings below are also paired with an updater API to change the settings at runtime, like `SUEnableAutomaticChecks` with [automaticallyChecksForUpdates](/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(py)automaticallyChecksForUpdates). The Info.plist settings are meant for default configuration, while the runtime APIs are in response to user setting changes. Please do not use the runtime APIs for setting initial default behavior. Check how to [add update settings](/documentation/preferences-ui/) for examples on changing user settings.
 
-### Info.plist Settings
+### General Settings
 
 {:.table .table-bordered}
 | Key | Type | Value |
@@ -26,13 +26,21 @@ Some of the Info.plist settings below are also paired with an updater API to cha
 | `SUAutomaticallyUpdate` | Boolean | Default: `NO`. Enables automatic download and installation of updates by default. If set to `YES`, Sparkle will attempt to download and install new updates silently in the background. Updates may be downloaded but not installed automatically if authorization is required. If the application hasn't quit for 1 week the user will be presented with installing the downloaded update (unless the updater delegate overrides this).<br/>This default property can later be overridden by setting [automaticallyDownloadsUpdates](/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(py)automaticallyDownloadsUpdates) in response to user setting changes (for example, the standard update alert has a checkbox for changing this).
 | `SUAllowsAutomaticUpdates` | Boolean | By default, Sparkle automatically presents your users with the *option* to allow to automatically download and install any available updates if automatic checking of updates is enabled.<br/>Set this to `NO` to disallow automatic updates and require manual installation every time.<br/>Set this to `YES` to always allow automatic updates even if automatic checking of updates is disabled. |
 | `SUEnableSystemProfiling` | Boolean | Default: `NO`. Enables anonymous system profiling. See [System Profiling](/documentation/system-profiling) for more. |
-| `SUVerifyUpdateBeforeExtraction` | Boolean | Default: `NO`. Set this to `YES` to force verification of updates before Sparkle extracts the downloaded update. Use this setting if you want stronger update validation and you aren't likely to lose access to your private EdDSA key (typically stored inside the macOS Keychain). EdDSA signing is required to use this setting. [Key rotation](/documentation/#rotating-signing-keys) is still possible by using Apple Developer ID code signed disk images as fallback. This setting is available in Sparkle 2.7 and later. |
 | `SUShowReleaseNotes` | Boolean | Default: `YES`. Set this to `NO` to hide release notes display from the update alert. |
-| `SUAllowedURLSchemes` | Array of Strings | An array of custom URL schemes allowed to be clicked from Sparkle's release notes view. By default, Sparkle only allows clicks to links that have a safe known URL scheme (like `https`). This setting is available in Sparkle 2.5 and later.
 | `SUBundleName` | String | Optional alternative bundle display name. For example, if your bundle name already has a version number appended to it, setting this may help smooth out certain messages, e.g. "MyApp 3 4.0 is now available" vs "MyApp 4.0 is now available". |
 | `SUDefaultsDomain` | String | Optional alternative `NSUserDefaults` domain name if you don't want to use the standard user defaults, for example when accessing preferences from an App Group suite. |
-| `SUEnableJavaScript` | Boolean | Default: `NO`. Set this to `YES` if you want to allow JavaScript in your release notes. |
 | `SURelaunchHostBundle` | Boolean | Default: `NO`. For plug-ins in Sparkle 2, set this to `YES` to re-launch the host targetted bundle instead of the application bundle. For example, this can be used to re-open a System Settings prefpane after an update has been installed.
+
+### Security Settings
+
+{:.table .table-bordered}
+| Key | Type | Value |
+| --- | ---- | ----- | ------- |
+| `SUVerifyUpdateBeforeExtraction` | Boolean | Default: `NO`. Set this to `YES` to force verification of updates before Sparkle extracts the downloaded update. Use this setting if you want stronger update validation and you aren't likely to lose access to your private EdDSA key (typically stored inside the macOS Keychain). EdDSA signing is required to use this setting. [Changing EdDSA keys](/documentation/#rotating-signing-keys) is still possible by using Apple Developer ID code signed disk images as a fallback. This setting is available since Sparkle 2.7. |
+| `SURequireSignedFeed` | Boolean | Default: `NO`. Set this to `YES` to make Sparkle validate appcasts and release notes are signed. Use this setting if you want secure validation of the update information presented to the user, and you aren't likely to lose access to your private EdDSA key (typically stored inside the macOS Keychain). This setting is available since Sparkle 2.9 (beta), and also requires enabling `SUVerifyUpdateBeforeExtraction` as a prerequisite.
+| `SUSignedFeedFailureExpirationInterval` | Number | The number of seconds it takes for a feed signing validation failure to expire. The default is `1728000` (20 days), and a special value of `0` disables feed signing failures from expiring. If Sparkle hasn't successfully validated a feed for this amount of time after the first signing failure, it will finally present new updates to users. This setting is a failsafe in case you lose access to your EdDSA signing keys, but can still serve updates through [rotating keys](/documentation/#rotating-signing-keys). In this scenario, release notes are not shown and informational only updates are not supported. `SURequireSignedFeed` must be enabled for this setting to take effect.
+| `SUAllowedURLSchemes` | Array of Strings | An array of custom URL schemes allowed to be clicked from Sparkle's release notes view. By default, Sparkle only allows clicks to links that have a safe known URL scheme (like `https`). This setting is available in Sparkle 2.5 and later.
+| `SUEnableJavaScript` | Boolean | Default: `NO`. Set this to `YES` if you want to allow JavaScript in your release notes. |
 
 ### Sandboxing Settings
 

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -19,11 +19,6 @@ If you use [Swift Package Manager](https://swift.org/package-manager/):
 
     From Xcode's project navigator, if you right click and show the `Sparkle` package in Finder, you will find Sparkle's tools to generate and sign updates in `../artifacts/sparkle/Sparkle/bin/` (in Finder you may need to go up one folder from `checkouts` via `Go › Enclosing Folder`).
 
-If you use [CocoaPods](//cocoapods.org):
-
-  * Add `pod 'Sparkle'` to your Podfile.
-  * Add or uncomment `use_frameworks!` in your Podfile.
-
 If you use [Carthage](https://github.com/Carthage/Carthage):
   * Add `binary "https://sparkle-project.org/Carthage/Sparkle.json"` to your Cartfile.
   * Run `carthage update`
@@ -40,6 +35,11 @@ If you use [Carthage](https://github.com/Carthage/Carthage):
 
     Sparkle only supports using a `binary` origin with Carthage because Carthage strips necessary code signing information when building the project from source.
 
+If you use [CocoaPods](//cocoapods.org) ([deprecated](https://blog.cocoapods.org/CocoaPods-Specs-Repo/)):
+
+  * Add `pod 'Sparkle'` to your Podfile.
+  * Add or uncomment `use_frameworks!` in your Podfile.
+
 If you want to add Sparkle manually:
 
 * Get the [latest version](//github.com/{{ site.github_username }}/Sparkle/releases/latest) of Sparkle.
@@ -53,7 +53,7 @@ If you want to add Sparkle manually:
   * Click on the <samp>General</samp> tab.
   * In <samp>Frameworks, Libraries, and Embedded Content</samp> section, change Sparkle.framework to <samp>Embed & Sign</samp>.
 * In <samp>Build Settings</samp> tab set "<samp>Runpath Search Paths</samp>" to `@loader_path/../Frameworks` (for non-Xcode projects add the flags `-Wl,-rpath,@loader_path/../Frameworks`). By default, recent versions of Xcode set this to `@executable_path/../Frameworks` which is already sufficient for regular applications.
-* If you have your own process for copying/packaging your app make sure it preserves symlinks!
+* If you have your own process for copying/packaging your app make sure it preserves symlinks and executable permissions!
 
 ---
 
@@ -61,9 +61,9 @@ If you enable Library Validation, which is part of the Hardened Runtime and requ
 
 If your application is sandboxed, please also follow the [sandboxing guide](/documentation/sandboxing). Otherwise, you may optionally be interested in [removing Sparkle's XPC Services](/documentation/sandboxing#removing-xpc-services) to save space.
 
-[Pre-releases](//github.com/{{ site.github_username }}/Sparkle/releases) when available are published on GitHub. They are also available in Swift Package Manager, CocoaPods, and Carthage too by specifying the pre-release version in your project's manifest.
+[Pre-releases](//github.com/{{ site.github_username }}/Sparkle/releases) when available are published on GitHub. They are also available in Swift Package Manager, Carthage, and CocoaPods too by specifying the pre-release version in your project's manifest.
 
-A more nightly build from our repository can be downloaded from our [GitHub Actions page](https://github.com/sparkle-project/Sparkle/actions?query=event%3Apush+is%3Asuccess+branch%3A2.x) by selecting a recent workflow commit and downloading the `Sparkle-distribution*.tar.xz` artifact. Alternatively, you may clone Sparkle's repository, run `make release`, and extract the binaries in the resulting `Sparkle-*.tar.xz` (or `.bz2`) archive.
+A more nightly build from our repository can be downloaded from our [GitHub Actions page](https://github.com/sparkle-project/Sparkle/actions?query=event%3Apush+is%3Asuccess+branch%3A2.x) by selecting a recent workflow commit and downloading the `Sparkle-distribution*.tar.xz` artifact. Alternatively, you may clone Sparkle's repository, run `make release`, and extract the binaries in the resulting `Sparkle-*.tar.xz` archive.
 
 ### 2. Set up a Sparkle updater object
 
@@ -83,17 +83,11 @@ That's it. No other API calls are required to start the updater and have it mana
 
 ### 3. Segue for security concerns
 
-Because Sparkle is downloading executable code to your users' systems, you must be very careful about security. To let Sparkle know that a downloaded update is not corrupted and came from you (instead of a malicious attacker), we recommend:
+Because Sparkle is installing executable code to your users' systems, you must be very careful about security. To let Sparkle know that a downloaded update is not corrupted and came from you (instead of a malicious attacker), we recommend:
 
-  * Serve updates over HTTPS.
-    * Your app *will not update* unless you comply with Apple's [App Transport Security](/documentation/app-transport-security/) requirements. HTTP requests will be rejected by the system.
-    * You can get free certificates from [Let's Encrypt](https://certbot.eff.org/), and test [server configuration](https://mozilla.github.io/server-side-tls/ssl-config-generator/) with [ssltest](https://www.ssllabs.com/ssltest/).
-  * Sign the application via Apple's Developer ID program.
-  * Sign the published update archive with Sparkle's EdDSA (ed25519) signature.
-    * Updates using [Installer package](/documentation/package-updates/) (`.pkg`) *must* be signed with EdDSA.
-    * [Binary Delta updates](/documentation/delta-updates/) *must* be signed with EdDSA.
-    * [Updates of preference panes and plugins](/documentation/bundles/) *must* be signed with EdDSA.
-    * Updates to regular application bundles that are signed with Apple's Developer ID program are strongly recommended to be signed with EdDSA for better security and fallback. Not using EdDSA signing for these updates is deprecated.
+  * Serve updates over HTTPS and comply with Apple's [App Transport Security requirements](/documentation/app-transport-security/).
+  * Notarize and code sign the application via Apple's Developer ID program (if possible). To diagnose basic code signing issues, you can run `codesign --deep --verify <path-to-app>`.
+  * Sign the published update archive (dmg, zip, etc), [binary delta updates](/documentation/delta-updates/), and [installer packages](/documentation/package-updates/) with Sparkle's EdDSA (ed25519) signature.
 
 Please ensure your signing keys are kept safe and cannot be stolen if your web server is compromised. One way to ensure this for example is not having your signing keys accessible from the machine that is hosting your product.
 
@@ -119,59 +113,57 @@ updates. It should appear like this:
     <string>pfIShU4dEXqPd5ObYNfDBiQWcXozk7estwzTnF9BamQ=</string>
 ```
 
-You can use the `-x private-key-file` and `-f private-key-file` options to export and import the keys respectively when transferring keys to another Mac. Otherwise we recommend keeping the keys inside your Mac's keychain. Be sure to keep them safe and not lose them (they will be erased if your keychain or system is erased).
-
-If your keys are lost however, you can still sign new updates for Developer ID signed applications through [key rotation](#rotating-signing-keys). Note this will not work for Installer package based updates or for applications that are not code signed. In those cases you may lose the ability to sign new updates.
+Be sure to keep your keys safe and not lose them (they will be erased if your keychain or system is erased). You can use the `-x private-key-file` and `-f private-key-file` options to export and import the keys respectively when transferring keys to another Mac. Otherwise we recommend keeping the keys inside your Mac's keychain. If your keys are lost however, you can still sign new updates for Developer ID signed applications through [key rotation](#rotating-signing-keys).
 
 Please visit [Migrating to EdDSA from DSA](eddsa-migration) if you are still providing DSA signatures so you can learn how to stop supporting them.
 
-#### Apple code signing
+#### Signing feeds (optional)
 
-If you are code-signing your application via Apple's Developer ID program, Sparkle will ensure the new version's author matches the old version's. Sparkle also performs shallow (but not deep) validation for testing if the new application's code signature is valid.
-  * Note that embedding the `Sparkle.framework` into the bundle of a Developer ID application requires that you code-sign the framework and its helper tools with your Developer ID keys. Xcode should do this automatically if you create an archive via <samp>Product › Archive</samp> and <samp>Distribute App</samp> choosing <samp>Developer ID</samp> method of distribution.
-  * You can diagnose code signing problems with `codesign --deep -vvv --verify <path-to-app>` for code signing validity, `spctl -a -t exec -vv <path-to-app>` for Gatekeeper validity, and by checking logs in the Console.app. See Apple's [Code Signing in Depth](https://developer.apple.com/library/archive/technotes/tn2206/_index.html) for more code signing details.
+For greater security, you can opt into signing your update feed and release notes by enabling [SURequireSignedFeed](/documentation/customization/#security-settings). This validates the information presented to the user. For example, with a signed feed, an attacker that compromises an app's update server will not be able to inform and trick existing users to update from another location.
+
+[SUVerifyUpdateBeforeExtraction](/documentation/customization/#security-settings) must also be enabled to use signed feeds. This option enforces validation of update archives before extracting them.
+
+With these options, more responsibility is on the developer to keep their signing keys safe and ensure their feeds and release notes stay correctly signed (modifications to these files will require re-signing them). For signed feeds, the [SUSignedFeedFailureExpirationInterval](/documentation/customization/#security-settings) option allows a limited fallback through [key rotation](#rotating-signing-keys) in case a feed hasn't been successfully validated for a lengthy period of time. Note when feed signing failures expire, Sparkle strips out information like release notes, links, and certain elements.
+
+Signed feeds are validated as of Sparkle 2.9 (beta).
 
 #### Rotating signing keys
 
-For regular application updates, if you both code-sign your application with Apple's Developer ID program and include a public EdDSA key for signing your update archive, Sparkle allows rotating keys by issuing a new update that changes either your Apple code signing certificate or your EdDSA keys (but not both). For applications that opt into enabling [SUVerifyUpdateBeforeExtraction](/documentation/customization/), the update archive must also be an Apple Developer ID code signed disk image.
+For regular application updates (not installer package updates), if you both code-sign your application with Apple's Developer ID program and include a public EdDSA key for signing your update archive, Sparkle allows rotating keys by issuing a new update that changes either your Apple code signing certificate or your EdDSA keys (but not both). For applications that opt into enabling [SUVerifyUpdateBeforeExtraction](/documentation/customization/#security-settings), changing your EdDSA keys can only be done if the update archive is a Developer ID code signed disk image (dmg).
 
 We recommend rotating keys only when necessary like if you need to change your Developer ID certificate, lose access to your EdDSA private key, or need to change (Ed)DSA keys due to [migrating away from DSA](eddsa-migration).
 
 ### 4. Distributing your App
 
-We recommend distributing your app in Xcode by creating a <samp>Product › Archive</samp> and <samp>Distribute App</samp> choosing <samp>Developer ID</samp> method of distribution. Using Xcode's Archive Organizer will ensure Sparkle's helper tools are code signed properly for distribution. In automated environments, this can instead be done using `xcodebuild archive` and `xcodebuild -exportArchive`.
+We recommend building your distributable app in Xcode by creating a <samp>Product › Archive</samp> and <samp>Distribute App</samp> choosing <samp>Developer ID</samp> method of distribution. Using Xcode's Archive Organizer will ensure Sparkle's helper tools are code signed properly for distribution. In automated environments, this process can be done using `xcodebuild archive` and `xcodebuild -exportArchive`.
 
-If you distribute your app on your website as a [Apple-certificate-signed disk image](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG17) (DMG):
+If you distribute your app on your website as a [notarized and Developer ID signed disk image](https://developer.apple.com/library/content/technotes/tn2206/_index.html#//apple_ref/doc/uid/DTS40007919-CH1-TNTAG17) (recommended), add an `/Applications` symlink in your disk image to encourage users to copy the app out of it.
 
-  * Add an `/Applications` symlink in your DMG, to encourage the user to copy the app out of it.
-  * Make sure the DMG is signed with a Developer ID and use macOS 10.11.5 or later to sign it (an older OS may not sign correctly). Signed DMG archives are backwards compatible.
+If you distribute your app on your website as a zip or a tar archive, avoid placing anything but your app inside the archive so you can minimize [app translocation](https://lapcatsoftware.com/articles/app-translocation.html) issues.
 
-If you distribute your app on your website as a ZIP or a tar archive (due to [app translocation](https://lapcatsoftware.com/articles/app-translocation.html)):
+Note by default Sparkle will not notify your user if an update cannot be performed, like if the app is running from a read-only mount or being impacted by app translocation.
 
-  * Avoid placing your app inside another folder in your archive, because copying of the folder as a whole doesn't remove the quarantine.
-  * Avoid putting more than just the single app in the archive.
-
-If your app is running from a read-only mount, you can encourage (if you want) your user to move the app into /Applications. Some frameworks, although not officially sanctioned here, exist for this purpose. Note Sparkle will not by default automatically disturb your user if an update cannot be performed.
-
-Sparkle supports updating from DMG, ZIP archives, tarballs, Apple Archives (as of Sparkle 2.7 / macOS 10.15), and [installer packages](/documentation/package-updates/), so you can generally reuse the same archive for distribution of your app on your website as well as Sparkle updates.
+Sparkle supports updating from dmg, zip archives, tarballs, Apple Archives (as of Sparkle 2.7 / macOS 10.15), and [installer packages](/documentation/package-updates/), so you can generally reuse the same archive for distribution of your app on your website as well as Sparkle updates.
 
 ### 5. Publish your appcast
 
 Sparkle uses appcasts to get information about software updates. An appcast is an RSS feed with some extra information for Sparkle's purposes.
 
-  * Add a [`SUFeedURL`](/documentation/customization/) property to your `Info.plist`; set its value to a URL where your appcast will be hosted, e.g. `https://yourcompany.example.com/appcast.xml`. We [strongly encourage you to use HTTPS](/documentation/app-transport-security/) URLs for the appcast.
+  * Add a [`SUFeedURL`](/documentation/customization/) property to your `Info.plist`; set its value to a URL where your appcast will be hosted, e.g. `https://yourcompany.example.com/appcast.xml`.
   * Note that your app bundle must have an incrementing and [properly formatted `CFBundleVersion`](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion) key in your `Info.plist`. Sparkle uses this to compare and determine the latest version of your bundle.
 
 If you update regular app bundles and you have set up EdDSA signatures, you can use a tool to generate appcasts automatically:
 
-  1. Build your app and compress it (e.g. in a DMG/ZIP/tar.xz/.aar archive), and put the archive in a new folder. This folder will be used to store all your future updates.
+  1. Build your app and compress it (e.g. in a dmg/zip/tar.xz/aar archive), and put the archive in a new folder. This folder will be used to store all your future updates.
   2. Run `generate_appcast` tool from Sparkle's distribution archive specifying the path to the folder with update archives. Allow it to access the Keychain if it asks for it (it's needed to generate signatures in the appcast).
 
         ./bin/generate_appcast /path/to/your/updates_folder/
 
   3. The tool will generate the appcast file (using filename from [`SUFeedURL`](/documentation/customization/)) and also [`*.delta` update](/documentation/delta-updates/) files for faster incremental updates. Upload your archives, the delta updates, and the appcast to your server.
 
-When generating the appcast, if an `.html` file exists with the same name as the archive, then it will added as the `releaseNotesLink`. Run `generate_appcast -h` for a full overview and list of supported options.
+When generating the appcast, if an `.html` file exists with the same name as the archive, then it will added as the `releaseNotesLink`. As of Sparkle 2.9 (beta) and macOS 12, basic markdown support using a `.md` file has also been added. Run `generate_appcast -h` for a full overview and list of supported options.
+
+If your app opts into [SURequireSignedFeed](/documentation/customization/#security-settings), `generate_appcast` will also sign your appcast and release note files. If you make further modifications to your appcast or release notes, you will need to re-run generate_appcast to generate updated signatures.
 
 You can also create the appcast file manually (not recommended):
 

--- a/documentation/programmatic-setup/index.md
+++ b/documentation/programmatic-setup/index.md
@@ -125,7 +125,7 @@ import Sparkle
 
 ```
 
-Note Sparkle's standard user interface cannot display HTML release notes because macOS WebKit views cannot be used inside a Catalyst application. As of Sparkle 2.4 or later, you can use plain text release notes instead. For older versions of Sparkle, you can disable showing release notes by setting [SUShowReleaseNotes](/documentation/customization) to `NO`. A more advanced approach for using HTML release notes using Sparkle 2 is creating your own [custom user interface](/documentation/custom-user-interfaces), which may use an iOS WebKit view from the Catalyst side.
+Note Sparkle's standard user interface cannot display HTML release notes because macOS WebKit views cannot be used inside a Catalyst application. As of Sparkle 2.9 (beta) and Sparkle 2.4, you can use markdown (requires macOS 12+) and plain text release notes respectively instead. For even older versions of Sparkle, you can disable showing release notes by setting [SUShowReleaseNotes](/documentation/customization) to `NO`. Another more advanced alternative for using HTML release notes is creating your own [custom user interface](/documentation/custom-user-interfaces), which may use an iOS WebKit view from the Catalyst side.
 
 If you run into issues with loading the Sparkle framework from your plug-in at runtime, please refer to [Add the Sparkle framework to your project](/documentation/#1-add-the-sparkle-framework-to-your-project) where the setup guide talks about having the <samp>Runpath Search Paths</samp> set to `@loader_path/../Frameworks` and using an `Apple Development` certificate for development to satisfy Library Validation. This applies to the setup for the plug-in target as well.
 

--- a/files/sparkletestcast-signed.xml
+++ b/files/sparkletestcast-signed.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<!-- sparkle-sign-warning:
+IMPORTANT: This file was signed by Sparkle. Any modifications to this file requires re-signing this file with generate_appcast or sign_update! The signed signature will be embedded at the end of this file.
+-->
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/" version="2.0">
+    <channel>
+        <title>Sparkle Test App Changelog</title>
+        <link>http://sparkle-project.org/files/sparkletestcast.xml</link>
+        <description>Most recent changes with links to updates.</description>
+        <language>en</language>
+        <item>
+            <title>Version 3.0</title>
+            <link>https://sparkle-project.org</link>
+            <sparkle:version>3.0</sparkle:version>
+            <!-- Example of embedded release notes -->
+            <description><![CDATA[
+            <ul>
+              <li>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
+              <li>Suspendisse sed felis ac ante ultrices rhoncus. Etiam quis elit vel nibh placerat facilisis in id leo.</li>
+              <li>Vestibulum nec tortor odio, nec malesuada libero. Cras vel convallis nunc.</li>
+              <li>Suspendisse tristique massa eget velit consequat tincidunt. Praesent sodales hendrerit pretium.</li>
+            </ul>
+          ]]></description>
+            <pubDate>Sun, 27 Jul 2014 15:20:11 +0000</pubDate>
+            <enclosure url="https://sparkle-project.org/files/Sparkle%20Test%20App3.zip" length="107798" type="application/octet-stream" sparkle:edSignature="7cLALFUHSwvEJWSkV8aMreoBe4fhRa4FncC5NoThKxwThL6FDR7hTiPJh1fo2uagnPogisnQsgFgq6mGkt2RBw=="/>
+        </item>
+        <item>
+            <title>Version 2.0</title>
+            <link>https://sparkle-project.org</link>
+            <sparkle:version>2.0</sparkle:version>
+            <!-- Example of external signed release notes -->
+            <sparkle:releaseNotesLink sparkle:edSignature="4KjvG1GjKwXrxfqXbU1j2CYClEDdkMDp2Ii2ICV+Jgx00MDpHFLpLJ+/2tHy9Mp9bTUk5KlpCG1OWBu4nLKOCw==" sparkle:length="1467">
+          https://sparkle-project.org/release_notes/app_2.0.html
+        </sparkle:releaseNotesLink>
+            <pubDate>Sat, 26 Jul 2014 15:20:11 +0000</pubDate>
+            <enclosure url="https://sparkle-project.org/files/Sparkle%20Test%20App.zip" length="107758" type="application/octet-stream" sparkle:edSignature="5wv7MoSNI5UbwrH+fRFIauntNrHlFErA70M5O2JKzUb+hQTcMwTwvwvzHdkYzxtfQMxx9w0MiD299OSovqVfCw=="/>
+        </item>
+    </channel>
+</rss><!-- sparkle-signatures:
+edSignature: LhZzxLxXCnbKLq4PGci8dGVsrPCzXUM5uech2cSAIQo37rMEj7f1gPO48h5wYGrAi/Kr8QTLhZUl5dueLxVvDA==
+length: 2578
+-->


### PR DESCRIPTION
Includes feed signing, markdown, hardware requirements element, minimum update version requirement, and modernizing other places for website documentation